### PR TITLE
Adding SHA-256 and SHA-512 password hashing support via CRYPT

### DIFF
--- a/contrib/gosa.conf.5
+++ b/contrib/gosa.conf.5
@@ -988,10 +988,12 @@ should return an integer value.
 The
 .I passwordDefaultHash
 statement defines the default password hash to choose for new accounts. Valid values are
-.I crypt/standard-des, crypt/md5, crypt/enhanced-des, crypt/blowfish, md5, sha, ssha, smd5, clear
+.I crypt/standard-des, crypt/md5, crypt/enhanced-des, crypt/blowfish, crypt/sha256, crypt/sha512,
+.I md5, sha, ssha, smd5, clear
 and
 .I sasl.
-These values will be overridden when using templates.
+The complete list is displayed in the "Password storage" pull-down menu in each user's "Generic/Personal Information" view.
+These values will be overridden when using templates. 
 .PP
 
 .B idGenerator

--- a/include/password-methods/class_password-methods-crypt.inc
+++ b/include/password-methods/class_password-methods-crypt.inc
@@ -74,14 +74,6 @@ class passwordMethodCrypt extends passwordMethod
       $salt .= "\$";
     }
 
-    if ($this->hash == "crypt/sha512"){ 
-      $salt = "\$6\$";
-      for ($i = 0; $i < 8; $i++) { 
-          $salt .= get_random_char();
-      }
-      $salt .= "\$";
-    }
-
     if ($this->hash == "crypt/sha256"){
       $salt = "\$5\$";
       for ($i = 0; $i < 16; $i++) {
@@ -120,10 +112,6 @@ class passwordMethodCrypt extends passwordMethod
       $hashes[]= "crypt/blowfish";
     }
 
-    if (CRYPT_SHA512 == 1) {
-      $hashes[] = "crypt/sha512";
-    }
-
     if (CRYPT_SHA256 == 1) {
       $hashes[]= "crypt/sha256";
     }
@@ -157,10 +145,6 @@ class passwordMethodCrypt extends passwordMethod
 
     if (preg_match('/^(\$2\$|\$2a\$)/', $password_hash)){
       return "crypt/blowfish";
-    }
-
-    if (preg_match('/^\$6\$/', $password_hash)){
-      return "crypt/sha512";
     }
 
     if (preg_match('/^\$5\$/', $password_hash)){

--- a/include/password-methods/class_password-methods-crypt.inc
+++ b/include/password-methods/class_password-methods-crypt.inc
@@ -82,6 +82,21 @@ class passwordMethodCrypt extends passwordMethod
       $salt .= "\$";
     }
 
+    if ($this->hash == "crypt/sha256"){
+      $salt = "\$5\$";
+      for ($i = 0; $i < 16; $i++) {
+          $salt .= get_random_char();
+      }
+      $salt .= "\$";
+    }
+
+    if ($this->hash == "crypt/sha512"){
+      $salt = "\$6\$";
+      for ($i = 0; $i < 16; $i++) {
+          $salt .= get_random_char();
+      }
+      $salt .= "\$";
+    }
     return "{CRYPT}".crypt($pwd, $salt);
   }
 
@@ -109,6 +124,13 @@ class passwordMethodCrypt extends passwordMethod
       $hashes[] = "crypt/sha512";
     }
 
+    if (CRYPT_SHA256 == 1) {
+      $hashes[]= "crypt/sha256";
+    }
+
+    if (CRYPT_SHA512 == 1) {
+      $hashes[]= "crypt/sha512";
+    }
     return $hashes;
   }
 
@@ -141,6 +163,13 @@ class passwordMethodCrypt extends passwordMethod
       return "crypt/sha512";
     }
 
+    if (preg_match('/^\$5\$/', $password_hash)){
+      return "crypt/sha256";
+    }
+
+    if (preg_match('/^\$6\$/', $password_hash)){
+      return "crypt/sha512";
+    }
     return "";
   }
 


### PR DESCRIPTION
This PR adds support for SHA-256 and SHA-512 password hashing via CRYPT, both of which are supported by any modern openldap server (and probably any other ldap server using standard CRYPT libs). 