### PR TITLE
Use base64 encoding on passwords sent to shell hooks to avoid RCE

### DIFF
--- a/contrib/gosa.conf.5
+++ b/contrib/gosa.conf.5
@@ -98,9 +98,25 @@ For every plugin, you can provide at least seven additional hooks:
 .I postmodify
 and
 .I check.
+.PP
 These can be used to perform special actions when a plugins gets
 a create, delete, modify or check request. As a parameter, these
 keywords get a shell script or program to the task.
+.PP
+NOTE: Any hook call using data input from users (ie: passwords) should take measures
+to prevent shell injection attacks that could lead to RCE. Specifically with Passwords,
+Gosa has been updated to base64 encode new_password and current_password used for all hook
+calls to mitigate this risk. All other values get escapeShellArg() escaped only, which
+can be exploited in certain conditions. Any hook using a password value needs to base64
+decode the value before using it.
+.PP
+.B Example password hook:
+to run a single command, like gam, to update passwords, in User Password premodify:
+.PP
+.RS
+/usr/local/bin/gam update user %uid password $(echo %new_password|base64 -d)
+.RE
+.PP
 
 .I The
 .B create / delete / modify

--- a/include/functions.inc
+++ b/include/functions.inc
@@ -2944,8 +2944,9 @@ function change_password ($dn, $password, $mode=FALSE, $hash= "", $old_password 
         foreach($attrs as $name => $value){
             $attrsEvent[$name] = $value;
         }
-        $attrsEvent['current_password'] = $old_password;
-        $attrsEvent['new_password'] = $password;
+        // base64_encode passwords to avoide shell injection via user-set passwords
+        $attrsEvent['current_password'] = base64_encode($old_password);
+        $attrsEvent['new_password'] = base64_encode($password);
         $attrsEvent['bind_dn'] = $config->current['ADMINDN'];
         $attrsEvent['bind_server'] = $config->current['SERVER'];
         $attrsEvent['bind_password'] = $config->get_credentials($config->current['ADMINPASSWORD']);


### PR DESCRIPTION
escapeshellarg() is not that great at what it is intended to do, especially when not used with escapeshellcmd(). Even if it is, there are known ways to exploit it. Our sec team identified that the way escapeshellarg() is used in Gosa for hook calls, allows a user to set carefully crafted values  to perform RCE via injection attacks. It also caused problems with certain special characters being used by password managers. A safer way to pass user input data to a shell command is to base64 encode the value, and have the hook command itself use "base64 -d" on the value to have it properly passed as a single argument that will not get interpolated by the shell. Since passwords are the most likely parameter passed via hooks, are set by the user directly, and can contain any valid character including very problematic ones that many shells will act on, this is the minimal fix that should be done. Any/all values settable by untrusted users, that get passed to shell unchecked, should use this method. Note that this will require password_hook configs to call a base64 decoder as part of their command, either in a shell script or directly in the hook config line. 
ex:

User Passoword premodify hook:
/usr/local/bin/gam update user %uid password $(echo %new_password|/usr/bin/base64 -d)

This would call gam (google account manager) to sync a password change from gosa into google, using the base64 program available in most linux distros.