### PR TITLE
Native ntlm passwords

### DIFF
--- a/contrib/gosa.conf.5
+++ b/contrib/gosa.conf.5
@@ -1075,9 +1075,11 @@ If not blank, Gosa will generate an NTLM hash when a user's password is set, and
 will lock/unlock this when the account is locked/unlocked using internal functions.
 LM hashing is intentionally broken (sets the LM hash to a non-valid string) as the
 method is ancient, broken, and rainbow tables exist for all passwords to it. IFF it
-is needed, set this field to "LM" and a valid LM hash will be set.
-Note that Gosa does not use this to specify an actual Hook command, it only cares
-if its empty, not empty, or contains "LM". Safe default: "YES" or leave blank.
+is needed, set this field to "NTLM+LM" and a valid LM hash will be set along side
+the NTLM one. Note that Gosa does not use this to specify an actual Hook command,
+it only cares if its empty, not empty, or contains "NTLM+LM".
+.PP
+Safe default: "NTLM" or leave blank.
 .PP
 
 .B sambaIdmapping

--- a/contrib/gosa.conf.5
+++ b/contrib/gosa.conf.5
@@ -1066,18 +1066,18 @@ inside of the LDAP.
 .PP
 
 .B sambaHashHook
-.I path
+.I string
 .PP
 The
 .I sambaHashHook
-statement contains an executable to generate samba hash values. This is required
-for password synchronization, but not required if you apply gosa-si services.
-If you don't have mkntpasswd from the samba distribution installed, you can use
-perl to generate the hash. Keep in mind to pass the value base64 encoded to perl:
-
-.nf
-perl -MCrypt::SmbHash -e "print join(q[:], ntlmgen decode_base64('\\$ARGV[0]')), $/;"
-.if
+Field, if blank, samba passwords are not generated or manipulated.
+If not blank, Gosa will generate an NTLM hash when a user's password is set, and 
+will lock/unlock this when the account is locked/unlocked using internal functions.
+LM hashing is intentionally broken (sets the LM hash to a non-valid string) as the
+method is ancient, broken, and rainbow tables exist for all passwords to it. IFF it
+is needed, set this field to "LM" and a valid LM hash will be set.
+Note that Gosa does not use this to specify an actual Hook command, it only cares
+if its empty, not empty, or contains "LM". Safe default: "YES" or leave blank.
 .PP
 
 .B sambaIdmapping

--- a/include/functions.inc
+++ b/include/functions.inc
@@ -3112,8 +3112,8 @@ function NThash($Input)
   $pwInput=iconv('UTF-8','UTF-16LE',$Input);
 
   // Encrypt it with the MD4 hash
-  if (phpversion("hash") ){
-    $MD4Hash=bin2hex(hash('md4',$pwInput));
+  if (extension_loaded("hash")) {
+    $MD4Hash=hash('md4',$pwInput);
   } else {
     $MD4Hash=bin2hex(mhash(MHASH_MD4,$pwInput));
   }
@@ -3150,18 +3150,17 @@ function LMhash_DESencrypt($Input)
 
   //Each keys is used to DES-encrypt the constant ASCII string "KGS!@#$%"
   //(resulting in two 8-byte ciphertext values).
-  if (phpversion("openssl")) {
+  if (extension_loaded('openssl')) {
     $is = openssl_cipher_iv_length('des-ecb');
-    $iv = openssl_random_pseudo_bytes($iv);
+    $iv = openssl_random_pseudo_bytes($is);
     $key0 = "";
     foreach ($key as $k)
       $key0 .= chr($k);
-    $LMHash = openssl_encrypt($msg, 'des-ecb', $key0, $options=0, $iv);
+    $LMHash = openssl_encrypt($msg, 'des-ecb', $key0, OPENSSL_RAW_DATA|OPENSSL_ZERO_PADDING, $iv);
   } else {
     $is = mcrypt_get_iv_size(MCRYPT_DES, MCRYPT_MODE_ECB);
     $iv = mcrypt_create_iv($is, MCRYPT_RAND);
     $key0 = "";
-
     foreach ($key as $k)
       $key0 .= chr($k);
     $LMHash = mcrypt_encrypt(MCRYPT_DES, $key0, $msg, MCRYPT_MODE_ECB, $iv);

--- a/include/functions.inc
+++ b/include/functions.inc
@@ -3124,14 +3124,18 @@ function NThash($Input)
 }
 
 // Really Really should disable this and just output invalid junk
-// since this hashing method is very very broken...
+// since this hashing method is very very broken... disabled unless 
+// config for sambaHashHook is set specifically to "LM"
 function LMhash($Input)
 {
-  // return('abunchofinvalidjunk!');
-  $Input = strtoupper(substr($Input,0,14));
-  $p1 = LMhash_DESencrypt(substr($Input, 0, 7));
-  $p2 = LMhash_DESencrypt(substr($Input, 7, 7));
-  return strtoupper($p1.$p2);
+  $lmhash = 'abunchofinvalidjunk!';
+  if (trim($config->get_cfg_value('core','sambaHashHook')) == 'LM') {
+    $Input = strtoupper(substr($Input,0,14));
+    $p1 = LMhash_DESencrypt(substr($Input, 0, 7));
+    $p2 = LMhash_DESencrypt(substr($Input, 7, 7));
+    $lmhash = strtoupper($p1.$p2);
+  }
+  return $lmhash;
 }
 
 function LMhash_DESencrypt($Input)

--- a/include/functions.inc
+++ b/include/functions.inc
@@ -3087,21 +3087,10 @@ function generate_smb_nt_hash($password)
     }
 
   } else {
-      $password = addcslashes($password, '$'); // <- Escape "$" once to be able to use it in pw strings in Perl scripts
-      $tmp = $config->get_cfg_value("core",'sambaHashHook');
-      $tmp = preg_replace("/%userPassword/", base64_encode($password), $tmp);
-      $tmp = preg_replace("/%password/", base64_encode($password), $tmp);
-	  @DEBUG (DEBUG_LDAP, __LINE__, __FUNCTION__, __FILE__, $tmp, "Execute");
 
- 	  exec($tmp, $ar);
-	  flush();
-	  reset($ar);
-	  $hash= current($ar);
+    $nt=NThash($password);
+    $lm=LMhash($password);
 
-    if ($hash == "") {
-      msg_dialog::display(_("Configuration error"), sprintf(_("Generating SAMBA hash by running %s failed: check %s!"), bold($config->get_cfg_value("core",'sambaHashHook'), bold("sambaHashHook"))), ERROR_DIALOG);
-      return(array());
-    }
   }
 
   list($lm,$nt)= explode(":", trim($hash));
@@ -3114,6 +3103,71 @@ function generate_smb_nt_hash($password)
   return($attrs);
 }
 
+// NT and LM functions with version checks for hash vs mhash and openssl vs mcrypt
+// (openssl and hash methods added by tmackey)
+// Original code from http://php.net/manual/en/ref.hash.php
+function NThash($Input)
+{
+  // Convert the password from UTF8 to UTF16 (little endian)
+  $pwInput=iconv('UTF-8','UTF-16LE',$Input);
+
+  // Encrypt it with the MD4 hash
+  if (phpversion("hash") ){
+    $MD4Hash=bin2hex(hash('md4',$pwInput));
+  } else {
+    $MD4Hash=bin2hex(mhash(MHASH_MD4,$pwInput));
+  }
+
+  // Make it uppercase, not necessary, but it's common to do so with NTLM hashes
+  $hash=strtoupper($MD4Hash);
+  return($hash);
+}
+
+function LMhash($Input)
+{
+  $Input = strtoupper(substr($Input,0,14));
+  $p1 = LMhash_DESencrypt(substr($Input, 0, 7));
+  $p2 = LMhash_DESencrypt(substr($Input, 7, 7));
+  return strtoupper($p1.$p2);
+}
+
+function LMhash_DESencrypt($Input)
+{
+  $msg = "KGS!@#$%";
+  $key = array();
+  $tmp = array();
+  $len = strlen($Input);
+  for ($i=0; $i<7; ++$i)
+  $tmp[] = $i < $len ? ord($Input[$i]) : 0;
+  $key[] = $tmp[0] & 254;
+  $key[] = ($tmp[0] << 7) | ($tmp[1] >> 1);
+  $key[] = ($tmp[1] << 6) | ($tmp[2] >> 2);
+  $key[] = ($tmp[2] << 5) | ($tmp[3] >> 3);
+  $key[] = ($tmp[3] << 4) | ($tmp[4] >> 4);
+  $key[] = ($tmp[4] << 3) | ($tmp[5] >> 5);
+  $key[] = ($tmp[5] << 2) | ($tmp[6] >> 6);
+  $key[] = $tmp[6] << 1;
+
+  //Each keys is used to DES-encrypt the constant ASCII string "KGS!@#$%"
+  //(resulting in two 8-byte ciphertext values).
+  if (phpversion("openssl")) {
+    $is = openssl_cipher_iv_length('des-ecb');
+    $iv = openssl_random_pseudo_bytes($iv);
+    $key0 = "";
+    foreach ($key as $k)
+      $key0 .= chr($k);
+    $LMHash = openssl_encrypt($msg, 'des-ecb', $key0, $options=0, $iv);
+  } else {
+    $is = mcrypt_get_iv_size(MCRYPT_DES, MCRYPT_MODE_ECB);
+    $iv = mcrypt_create_iv($is, MCRYPT_RAND);
+    $key0 = "";
+
+    foreach ($key as $k)
+      $key0 .= chr($k);
+    $LMHash = mcrypt_encrypt(MCRYPT_DES, $key0, $msg, MCRYPT_MODE_ECB, $iv);
+  }
+  return bin2hex($LMHash);
+}
 
 /*! \brief Get the Change Sequence Number of a certain DN
  *

--- a/include/functions.inc
+++ b/include/functions.inc
@@ -3103,8 +3103,8 @@ function generate_smb_nt_hash($password)
   return($attrs);
 }
 
-// NT and LM functions with version checks for hash vs mhash and openssl vs mcrypt
-// (openssl and hash methods added by tmackey)
+// NT and LM hashing functions 
+// using openssl and hash methods (no more mcrypt)
 // Original code from http://php.net/manual/en/ref.hash.php
 function NThash($Input)
 {
@@ -3125,11 +3125,11 @@ function NThash($Input)
 
 // Really Really should disable this and just output invalid junk
 // since this hashing method is very very broken... disabled unless 
-// config for sambaHashHook is set specifically to "LM"
+// config for sambaHashHook is set specifically to "NTLM+LM"
 function LMhash($Input)
 {
   $lmhash = 'abunchofinvalidjunk!';
-  if (trim($config->get_cfg_value('core','sambaHashHook')) == 'LM') {
+  if (trim($config->get_cfg_value('core','sambaHashHook')) == 'NTLM+LM') {
     $Input = strtoupper(substr($Input,0,14));
     $p1 = LMhash_DESencrypt(substr($Input, 0, 7));
     $p2 = LMhash_DESencrypt(substr($Input, 7, 7));
@@ -3157,21 +3157,12 @@ function LMhash_DESencrypt($Input)
 
   //Each keys is used to DES-encrypt the constant ASCII string "KGS!@#$%"
   //(resulting in two 8-byte ciphertext values).
-  if (extension_loaded('openssl')) {
-    $is = openssl_cipher_iv_length('des-ecb');
-    $iv = openssl_random_pseudo_bytes($is);
-    $key0 = "";
-    foreach ($key as $k)
-      $key0 .= chr($k);
-    $LMHash = openssl_encrypt($msg, 'des-ecb', $key0, OPENSSL_RAW_DATA|OPENSSL_ZERO_PADDING, $iv);
-  } else {
-    $is = mcrypt_get_iv_size(MCRYPT_DES, MCRYPT_MODE_ECB);
-    $iv = mcrypt_create_iv($is, MCRYPT_RAND);
-    $key0 = "";
-    foreach ($key as $k)
-      $key0 .= chr($k);
-    $LMHash = mcrypt_encrypt(MCRYPT_DES, $key0, $msg, MCRYPT_MODE_ECB, $iv);
-  }
+  $is = openssl_cipher_iv_length('des-ecb');
+  $iv = openssl_random_pseudo_bytes($is);
+  $key0 = "";
+  foreach ($key as $k)
+    $key0 .= chr($k);
+  $LMHash = openssl_encrypt($msg, 'des-ecb', $key0, OPENSSL_RAW_DATA|OPENSSL_ZERO_PADDING, $iv);
   return bin2hex($LMHash);
 }
 

--- a/include/functions.inc
+++ b/include/functions.inc
@@ -3090,7 +3090,7 @@ function generate_smb_nt_hash($password)
 
     $nt=NThash($password);
     $lm=LMhash($password);
-
+    $hash="$lm:$nt";
   }
 
   list($lm,$nt)= explode(":", trim($hash));
@@ -3123,8 +3123,11 @@ function NThash($Input)
   return($hash);
 }
 
+// Really Really should disable this and just output invalid junk
+// since this hashing method is very very broken...
 function LMhash($Input)
 {
+  // return('abunchofinvalidjunk!');
   $Input = strtoupper(substr($Input,0,14));
   $p1 = LMhash_DESencrypt(substr($Input, 0, 7));
   $p2 = LMhash_DESencrypt(substr($Input, 7, 7));


### PR DESCRIPTION
This PR uses native PHP to generate the NTLM and LM hashes. It also only generates a valid LM hash if the sambaHashHook config item is set specifically to "LM" since this hashing method is extremely old and broken, with full rainbow tables well known, that could weaken/compromise passwords stored using it. Most legacy things needing it should support NTLM which is better, and as such only junk will be returned unless LM hashing is specifically requested. Note that the sambaHashHook config field itself is only checked for empty/not-empty to determine if samba password manipulation should be enabled. It does not use the field to store an external command.
This replaces the need to spawn a shell and run perl, which required shell escaping/base64 encoding passwords.