### PR TITLE
Support disabling autocompletion in search boxes via config option.

### DIFF
--- a/contrib/gosa.conf.5
+++ b/contrib/gosa.conf.5
@@ -982,6 +982,15 @@ externaly. It gets called with the current entry "dn" and the attribute to be ID
 should return an integer value.
 .PP
 
+.B useAutoComplete
+.I bool
+.PP
+The
+.I useAutoComplete
+statement allows you to enable/disable the auto-completion mode when searching for LDAP
+objects in a given container. Enable it, if you encounter long typing delays in GOsa²'s
+search field.
+
 .B passwordDefaultHash
 .I string
 .PP

--- a/include/class_core.inc
+++ b/include/class_core.inc
@@ -476,6 +476,16 @@ class core extends plugin {
                                 "mandatory"     => FALSE),
 
                         array(
+                                "name"          => "useAutoComplete",
+                                "type"          => "bool",
+                                "default"       => "true",
+                                "description"   => _("use autocompletion in search boxes (performs preliminarily ldap searches)."),
+                                "check"         => "gosaProperty::isBool",
+                                "migrate"       => "",
+                                "group"         => "core",
+                                "mandatory"     => FALSE),
+
+                        array(
                                 "name"          => "storeFilterSettings",
                                 "type"          => "bool",
                                 "default"       => "true",

--- a/include/class_management.inc
+++ b/include/class_management.inc
@@ -166,7 +166,9 @@ class management
     if ($this->filter) {
       $this->filter->update();
       session::global_set(get_class($this)."_filter", $this->filter);
-      session::set('autocomplete', get_class($this)."_filter");
+      if ($this->config->get_cfg_value("core", "useAutoComplete") == "true") {
+        session::set('autocomplete', $this->filter);
+      }
     }
 
     // Handle actions (POSTs and GETs)


### PR DESCRIPTION
 Gives the site admin a work-around for the following issue:

 Some browsers (e.g. Safari) create a 2sec delay for each character typed
 into a search box.

 Other browsers (e.g. Firefox) interpret the ENTER key badly when
 autocompletion is enabled. Search results become borked by a combined
 search result of autocompletion result and what you actually typed into
 the search box.

 Furthermore, with disabled autocompletion, user lists in group objects
 don't become flawed (empty) after some usage steps. (The relation to the
 above phenomena is unclear, though).