### PR TITLE
bin/gosa-mcrypt-to-openssl-passwords: Make crypto-transition indepent…

### DIFF
--- a/bin/gosa-mcrypt-to-openssl-passwords
+++ b/bin/gosa-mcrypt-to-openssl-passwords
@@ -25,9 +25,7 @@ function cred_encrypt($input, $password, $cipher = "aes-256-ecb") {
 }
 
 function cred_decrypt($input, $password) {
-  $size = mcrypt_get_iv_size(MCRYPT_RIJNDAEL_128, MCRYPT_MODE_CBC);
-  $iv = mcrypt_create_iv($size, MCRYPT_DEV_RANDOM);
-  return rtrim(@openssl_decrypt( pack("H*", $input), "aes-256-ecb" , $password, OPENSSL_RAW_DATA | OPENSSL_ZERO_PADDING, $iv ), "\0\3\4\n");
+  return rtrim(@openssl_decrypt( pack("H*", $input), "aes-256-ecb" , $password, OPENSSL_RAW_DATA | OPENSSL_ZERO_PADDING, ), "\0\3\4\n");
 }
 
 


### PR DESCRIPTION
… from php-mcrypt being available.

  This change makes it possible to run the gosa-mcrypt-to-openssl-
  passwords script on systems that have PHP7.3 (or beyond) installed.
  (i.e. systems that lack php-mcrypt).

  For details see:
    https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=925138
  and esp.:
    https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=927306