### PR TITLE
Replace (un)serialize with json_encode/json_decode

### DIFF
--- a/html/index.php
+++ b/html/index.php
@@ -338,9 +338,9 @@ if (($_SERVER["REQUEST_METHOD"] == "POST" && isset($_POST['login'])) || $htacces
                 if(isset($_COOKIE['GOsa_Filter_Settings']) || isset($HTTP_COOKIE_VARS['GOsa_Filter_Settings'])) {
 
                     if(isset($_COOKIE['GOsa_Filter_Settings'])) {
-                        $cookie_all = unserialize(base64_decode($_COOKIE['GOsa_Filter_Settings']));
+                        $cookie_all = json_decode(base64_decode($_COOKIE['GOsa_Filter_Settings']));
                     }else{
-                        $cookie_all = unserialize(base64_decode($HTTP_COOKIE_VARS['GOsa_Filter_Settings']));
+                        $cookie_all = json_decode(base64_decode($HTTP_COOKIE_VARS['GOsa_Filter_Settings']));
                     }
                     if(isset($cookie_all[$ui->dn])) {
                         $cookie = $cookie_all[$ui->dn];

--- a/html/main.php
+++ b/html/main.php
@@ -481,9 +481,9 @@ $display= "<!-- headers.tpl-->".$smarty->fetch(get_template_path('headers.tpl'))
 $cookie = array();
 
 if(isset($_COOKIE['GOsa_Filter_Settings'])){
-  $cookie = unserialize(base64_decode($_COOKIE['GOsa_Filter_Settings']));
+  $cookie = json_decode(base64_decode($_COOKIE['GOsa_Filter_Settings']));
 }elseif(isset($HTTP_COOKIE_VARS['GOsa_Filter_Settings'])){
-  $cookie = unserialize(base64_decode($HTTP_COOKIE_VARS['GOsa_Filter_Settings']));
+  $cookie = json_decode(base64_decode($HTTP_COOKIE_VARS['GOsa_Filter_Settings']));
 }
 
 /* Save filters? */
@@ -497,7 +497,7 @@ if($config->get_cfg_value("core","storeFilterSettings") == "true"){
   if(isset($_GET['plug'])){
     $cookie[$ui->dn]['plug'] = $_GET['plug'];
   }
-  @setcookie("GOsa_Filter_Settings",base64_encode(serialize($cookie)),time() + (60*60*24));
+  @setcookie("GOsa_Filter_Settings",base64_encode(json_encode($cookie)),time() + (60*60*24));
 }
 
 /* Show page... */


### PR DESCRIPTION
GOsa currently uses `unserialize` to restore filter settings from a cookie. Since this cookie is supplied by the client, authenticated users can pass arbitrary content to `unserialized`, which opens GOsa up to a potential [PHP object injection](https://blog.ripstech.com/2018/php-object-injection/).

This PR protects against such issues by switching to the safe `json_decode` method.