### PR TITLE
CVE-2019-11187: Fix not strict enough check for LDAP success.

### DIFF
--- a/include/class_ldap.inc
+++ b/include/class_ldap.inc
@@ -931,7 +931,7 @@ class LDAP
 
     function success()
     {
-        return (preg_match('/Success/i', $this->error));
+        return (trim($this->error) === 'Success');
     }
 
 


### PR DESCRIPTION
  See https://security-tracker.debian.org/tracker/CVE-2019-11187

  The issue had been reported against GOsa, but has not yet been
  published on Mitre.org. In Debian, we have already fully addressed the
  issue and updates will be released with the next point releases
  of Debian stretch + buster. Debian jessie LTS already has this
  fix.