### PR TITLE
Fix the decoding of filter settings cookie

### DIFF
--- a/html/index.php
+++ b/html/index.php
@@ -338,9 +338,12 @@ if (($_SERVER["REQUEST_METHOD"] == "POST" && isset($_POST['login'])) || $htacces
                 if(isset($_COOKIE['GOsa_Filter_Settings']) || isset($HTTP_COOKIE_VARS['GOsa_Filter_Settings'])) {
 
                     if(isset($_COOKIE['GOsa_Filter_Settings'])) {
-                        $cookie_all = json_decode(base64_decode($_COOKIE['GOsa_Filter_Settings']));
+                        $cookie_all = json_decode(base64_decode($_COOKIE['GOsa_Filter_Settings']), true);
                     }else{
-                        $cookie_all = json_decode(base64_decode($HTTP_COOKIE_VARS['GOsa_Filter_Settings']));
+                        $cookie_all = json_decode(base64_decode($HTTP_COOKIE_VARS['GOsa_Filter_Settings']), true);
+                    }
+                    if(!is_array($cookie_all)) {
+                        $cookie_all = [];
                     }
                     if(isset($cookie_all[$ui->dn])) {
                         $cookie = $cookie_all[$ui->dn];

--- a/html/main.php
+++ b/html/main.php
@@ -481,9 +481,12 @@ $display= "<!-- headers.tpl-->".$smarty->fetch(get_template_path('headers.tpl'))
 $cookie = array();
 
 if(isset($_COOKIE['GOsa_Filter_Settings'])){
-  $cookie = json_decode(base64_decode($_COOKIE['GOsa_Filter_Settings']));
+  $cookie = json_decode(base64_decode($_COOKIE['GOsa_Filter_Settings']), true);
 }elseif(isset($HTTP_COOKIE_VARS['GOsa_Filter_Settings'])){
-  $cookie = json_decode(base64_decode($HTTP_COOKIE_VARS['GOsa_Filter_Settings']));
+  $cookie = json_decode(base64_decode($HTTP_COOKIE_VARS['GOsa_Filter_Settings']), true);
+}
+if(!is_array($cookie)) {
+  $cookie = [];
 }
 
 /* Save filters? */


### PR DESCRIPTION
(refs #29)

Previously, the use of json_decode without a second paramter meant that an
stdClass was returned, which does not allow access to properties via the index
operator. Instead, we now use json_decode(..., true) to return an associative
array.

In order to prevent any type shenanigans, we also check whether the returned
value is an array and if not, replace it with an empty one.