### PR TITLE
PHP 7.4 chokes on a flaw in cred_encrypt() and cred_decrypt() that pr…

### DIFF
--- a/bin/gosa-encrypt-passwords
+++ b/bin/gosa-encrypt-passwords
@@ -4,8 +4,15 @@
 function cred_encrypt($input, $password, $cipher = "aes-256-ecb") {
   if (in_array($cipher, openssl_get_cipher_methods())) {
     $ivlen = openssl_cipher_iv_length($cipher);
-    $iv = openssl_random_pseudo_bytes($ivlen);
-    return bin2hex(openssl_encrypt($input, $cipher, $password, OPENSSL_RAW_DATA, $iv));
+    $iv = "";
+    if ($ivlen > 0) {
+      $iv = openssl_random_pseudo_bytes($ivlen);
+    }
+
+    $encrypted = openssl_encrypt($input, $cipher, $password, OPENSSL_RAW_DATA, $iv);
+    if ($encrypted == false) return null;
+
+    return bin2hex($encrypted);
   }
 
   return null;

--- a/include/functions.inc
+++ b/include/functions.inc
@@ -3374,12 +3374,18 @@ function get_random_char () {
      }
 }
 
-
 function cred_encrypt($input, $password, $cipher = "aes-256-ecb") {
   if (in_array($cipher, openssl_get_cipher_methods())) {
     $ivlen = openssl_cipher_iv_length($cipher);
-    $iv = openssl_random_pseudo_bytes($ivlen);
-    return bin2hex(openssl_encrypt($input, $cipher, $password, OPENSSL_RAW_DATA, $iv));
+    $iv = "";
+    if ($ivlen > 0) {
+      $iv = openssl_random_pseudo_bytes($ivlen);
+    }
+
+    $encrypted = openssl_encrypt($input, $cipher, $password, OPENSSL_RAW_DATA, $iv);
+    if ($encrypted == false) return null;
+
+    return bin2hex($encrypted);
   }
 
   return null;
@@ -3388,8 +3394,15 @@ function cred_encrypt($input, $password, $cipher = "aes-256-ecb") {
 function cred_decrypt($input, $password, $cipher = "aes-256-ecb") {
   if (in_array($cipher, openssl_get_cipher_methods())) {
     $ivlen = openssl_cipher_iv_length($cipher);
-    $iv = openssl_random_pseudo_bytes($ivlen);
-    return rtrim(openssl_decrypt(pack("H*", $input), $cipher, $password, OPENSSL_RAW_DATA, $iv ), "\0\3\4\n");
+    $iv = "";
+    if ($ivlen > 0) {
+      $iv = openssl_random_pseudo_bytes($ivlen);
+    }
+    // If openssl_decrypt returns false: It can be a wrong `input` or the
+    // password in gosa.conf is not encrypted.
+    $decrypted = openssl_decrypt(pack("H*", $input), $cipher, $password, 0, $iv);
+    if ($decrypted == false) return null;
+    return rtrim($decrypted, "\0\3\4\n");
   }
 
   return null;


### PR DESCRIPTION
…evious PHP versions silently ignored.

  PHP 7.4 chokes with...

  ```
  Fatal error: Uncaught Error: Length must be greater than 0 in
  /usr/share/gosa/include/functions.inc:3324 Stack trace:
  #0 /usr/share/gosa/include/functions.inc(3324): openssl_random_pseudo_bytes()
  #1 /usr/share/gosa/include/class_config.inc(310): cred_decrypt()
  #2 /usr/share/gosa/include/class_config.inc(362): config->get_credentials()
  #3 /usr/share/gosa/include/class_configRegistry.inc(408): config->get_ldap_link()
  #4 /usr/share/gosa/include/class_config.inc(453): configRegistry->reload()
  #5 /usr/share/gosa/include/class_config.inc(441): config->load_servers()
  #6 /usr/share/gosa/html/index.php(267): config->set_current()
  #7 {main}
  thrown in /usr/share/gosa/include/functions.inc on line 3324
  ```
  ... because the chosen method (aes-256-ecb) doesn't use an
  initialization vector ($iv) at all, causing its length ($ivlen) to be 0,
  see e.g. https://usr.ed48.com/php/ssl/?xf=7

  So the encrypt/decrypt implementation seems to have been sort of wrong
  before (and only now with PHP 7.4 an error is thrown).

  See Debian bug https://bugs.debian.org/964318