### PR TITLE
openldap/gosa-samba3.*: Provide 'alias' attribute description by obje…

### DIFF
--- a/contrib/openldap/gosa-samba3.ldif
+++ b/contrib/openldap/gosa-samba3.ldif
@@ -571,6 +571,16 @@ olcAttributeTypes: (
   )
 #
 ################################################################################
+olcAttributeTypes: (
+  1.3.6.1.4.1.19414.2.1.3
+  NAME 'alias'
+  DESC 'RFC1274: RFC822 Mailbox'
+  EQUALITY caseIgnoreIA5Match
+  SUBSTR caseIgnoreIA5SubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26{256}
+)
+#
+################################################################################
 #
 olcObjectClasses: (
   1.3.6.1.4.1.10098.1.2.1.19.1
@@ -625,7 +635,7 @@ olcObjectClasses: (
   SUP top
   AUXILIARY
   MUST ( mail $ gosaMailServer $ gosaMailDeliveryMode )
-  MAY ( gosaMailQuota $ gosaMailAlternateAddress $ gosaMailForwardingAddress $ gosaMailMaxSize $ gosaSpamSortLevel $ gosaSpamMailbox $ gosaVacationMessage $ gosaVacationStart $ gosaVacationStop $ gosaSharedFolderTarget $ acl )
+  MAY ( alias $ gosaMailQuota $ gosaMailAlternateAddress $ gosaMailForwardingAddress $ gosaMailMaxSize $ gosaSpamSortLevel $ gosaSpamMailbox $ gosaVacationMessage $ gosaVacationStart $ gosaVacationStop $ gosaSharedFolderTarget $ acl )
   )
 #
 ################################################################################

--- a/contrib/openldap/gosa-samba3.schema
+++ b/contrib/openldap/gosa-samba3.schema
@@ -302,6 +302,14 @@ attributetype ( 1.3.6.1.4.1.19414.2.1.651
 		SUBSTR caseIgnoreIA5SubstringsMatch
 	    SYNTAX 1.3.6.1.4.1.1466.115.121.1.26{256} )
 
+# alias used to provide alternative rfc822 email addresses for kolab users
+attributetype ( 1.3.6.1.4.1.19414.2.1.3
+        NAME 'alias'
+        DESC 'RFC1274: RFC822 Mailbox'
+        EQUALITY caseIgnoreIA5Match
+        SUBSTR caseIgnoreIA5SubstringsMatch
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.26{256} )
+
 # Classes
 objectclass ( 1.3.6.1.4.1.10098.1.2.1.19.1 NAME 'gosaObject' SUP top AUXILIARY
         DESC 'Class for GOsa settings (v2.7)'
@@ -324,7 +332,7 @@ objectclass ( 1.3.6.1.4.1.10098.1.2.1.19.4 NAME 'gosaDepartment' SUP top AUXILIA
 objectclass ( 1.3.6.1.4.1.10098.1.2.1.19.5 NAME 'gosaMailAccount' SUP top AUXILIARY
         DESC 'Class to mark MailAccounts for GOsa (v2.7)'
 	MUST ( mail $ gosaMailServer $ gosaMailDeliveryMode)
-	MAY  ( gosaMailQuota $ gosaMailAlternateAddress $ gosaMailForwardingAddress $
+	MAY  ( alias $ gosaMailQuota $ gosaMailAlternateAddress $ gosaMailForwardingAddress $
 	       gosaMailMaxSize $ gosaSpamSortLevel $ gosaSpamMailbox $
 	       gosaVacationMessage $ gosaVacationStart $ gosaVacationStop $ gosaSharedFolderTarget $ acl))
 


### PR DESCRIPTION
…ctClass 'gosaMailAccount'.

 A very common use case in LDAP stored mail accounts is the definition
 of a primary mail address and mail address aliases. The add-on module
 gosa-plugin-mailaddress provides a field for adding e-mail aliases to
 user mail accounts.

 Up to now, the 'alias' attribute has only been provided to user accounts
 that were set up as kolabInetOrgPerson based accounts.

 With this change, the 'alias' attribute description gets provided
 for usual gosaMailAccount based accounts.

 This change comes together with a schema change in GOsa²'s kolab2.schema
 (where we comment out the 'alias' attribute description). Normally,
 Kolab Users maintained via GOsa² have the 'gosaMailAccount' objectClass
 already set, so 'alias' gets provided via gosa-samba3.schema all fine.