### PR TITLE
include/functions.inc: The $initialAttrs array in change_password() c…

### DIFF
--- a/include/functions.inc
+++ b/include/functions.inc
@@ -2984,7 +2984,8 @@ function change_password($dn, $password, $mode = FALSE, $hash = "", $old_passwor
     // Prepare a special attribute list, which will be used for event hook calls
     $attrsEvent = array();
     foreach ($initialAttrs as $name => $value) {
-      if (!is_numeric($name))
+      // $value can contain dn => <dn-string>, so skip that
+      if (!is_numeric($name) && is_array($value))
         $attrsEvent[$name] = $value[0];
     }
     $attrsEvent['dn'] = $initialAttrs['dn'];


### PR DESCRIPTION
…ontains the result of an LDAP fetch which contains the DN (and this is not an array), so skip that.