### PR TITLE
{bin/gosa-encrypt-passwords,include/functions.inc}: Hacky fix for the…

### DIFF
--- a/bin/gosa-encrypt-passwords
+++ b/bin/gosa-encrypt-passwords
@@ -6,12 +6,18 @@ function cred_encrypt($input, $password, $cipher = "aes-256-ecb") {
     $ivlen = openssl_cipher_iv_length($cipher);
     $iv = "";
     if ($ivlen > 0) {
-      $iv = openssl_random_pseudo_bytes($ivlen);
+       // fallback to a cipher that can handle empty iv strings
+       // we cannot handle IVs currently, as we need to store them somewhere persistently
+       // between encryption and decryption
+       $cipher = "aes-256-ecb";
     }
 
-    $encrypted = openssl_encrypt($input, $cipher, $password, OPENSSL_RAW_DATA, $iv);
+    echo "$input, $cipher, $password\n";
+    $encrypted = openssl_encrypt($input, $cipher, $password, $options=0, $iv);
     if ($encrypted == false) return null;
 
+    echo $encrypted."\n";
+    echo bin2hex($encrypted)."\n";
     return bin2hex($encrypted);
   }
 

--- a/include/functions.inc
+++ b/include/functions.inc
@@ -3400,12 +3400,13 @@ function cred_encrypt($input, $password, $cipher = "aes-256-ecb") {
     $ivlen = openssl_cipher_iv_length($cipher);
     $iv = "";
     if ($ivlen > 0) {
-      $iv = openssl_random_pseudo_bytes($ivlen);
+      // fallback to a cipher that can handle empty iv strings
+      // we cannot handle IVs currently, as we need to store them somewhere persistently
+      // between encryption and decryption
+      $cipher = "aes-256-ecb";
     }
-
-    $encrypted = openssl_encrypt($input, $cipher, $password, OPENSSL_RAW_DATA, $iv);
+    $encrypted = openssl_encrypt($input, $cipher, $password, $options=0, $iv);
     if ($encrypted == false) return null;
-
     return bin2hex($encrypted);
   }
 
@@ -3417,11 +3418,14 @@ function cred_decrypt($input, $password, $cipher = "aes-256-ecb") {
     $ivlen = openssl_cipher_iv_length($cipher);
     $iv = "";
     if ($ivlen > 0) {
-      $iv = openssl_random_pseudo_bytes($ivlen);
+      // fallback to a cipher that can handle empty iv strings
+      // we cannot handle IVs currently, as we need to store them somewhere persistently
+      // between encryption and decryption
+      $cipher = "aes-256-ecb";
     }
     // If openssl_decrypt returns false: It can be a wrong `input` or the
     // password in gosa.conf is not encrypted.
-    $decrypted = openssl_decrypt(pack("H*", $input), $cipher, $password, 0, $iv);
+    $decrypted = openssl_decrypt(hex2bin($input), $cipher, $password, $options=0, $iv);
     if ($decrypted == false) return null;
     return rtrim($decrypted, "\0\3\4\n");
   }


### PR DESCRIPTION
… current encrypt/decrypt problem.

 Two issues get addressed here:

 (1) 'pack("H*", $input)' is not behaving as expected, replace by
     hex2bin($input).

 (2) The iv strings (if other then empty strings) need to match at encryption
     _and_ decryption. We can only handle ciphers that allow for an empty iv
     string for now. Otherwise, we'd have to store the iv somewhere at
     encryption time and retrieve it back when decrypting.