### PR TITLE
fix indexing in else branch and change to NULL Coalescing

### DIFF
--- a/include/class_sortableListing.inc
+++ b/include/class_sortableListing.inc
@@ -760,9 +760,9 @@ class sortableListing
     public function getKey($index)
     {
         if (is_array($index)) {
-            return isset($this->keys[$index[0]])?$this->keys[$index[0]]:null;
+            return $this->keys[$index[0]] ?? null;
         } else {
-            return isset($this->keys[$index[0]])?$this->keys[$index]:null;
+            return $this->keys[$index] ?? null;
         }
     }
 


### PR DESCRIPTION
The If condition asks whether `$index` is an array. 
Accordingly, the value must be accessed directly in the else branch.

Additionally use a NULL coalescing to avoid an unnecessary `isset()` check.