### PR TITLE
Fix: https enforcement if enabled in gosa.conf

### DIFF
--- a/html/index.php
+++ b/html/index.php
@@ -211,12 +211,6 @@ if (
     }
 }
 
-/* If SSL is forced, just forward to the SSL enabled site */
-if ($config->get_cfg_value("core", "forceSSL") == 'true' && $ssl != '') {
-    header("Location: $ssl");
-    exit;
-}
-
 /* Do we have htaccess authentification enabled? */
 $htaccess_authenticated = false;
 if ($config->get_cfg_value("core", "htaccessAuthentication") == "true") {

--- a/html/password.php
+++ b/html/password.php
@@ -185,12 +185,6 @@ if (!isset($_SERVER['HTTPS']) ||
     }
 }
 
-/* If SSL is forced, just forward to the SSL enabled site */
-if ($config->get_cfg_value("core", "forceSSL") == 'true' && $ssl != '') {
-    header("Location: $ssl");
-    exit;
-}
-
 /* Check for selected password method */
 $method= $config->get_cfg_value("core", "passwordDefaultHash");
 if (isset($_GET['method'])) {

--- a/include/php_setup.inc
+++ b/include/php_setup.inc
@@ -343,7 +343,7 @@ $error_collector_mailto = '';
 $config = new config(CONFIG_DIR . '/' . CONFIG_FILE, $BASE_DIR);
 
 /* Enforce ssl if forced by gosa.conf */
-require_once __DIR__ . '/ssl_enforce.inc';
+require_once(__DIR__ . '/ssl_enforce.inc');
 enforce_ssl_if_forced();
 
 set_error_handler('gosaRaiseError', E_WARNING |  E_NOTICE | E_USER_ERROR | E_USER_WARNING | E_USER_NOTICE);

--- a/include/php_setup.inc
+++ b/include/php_setup.inc
@@ -342,6 +342,10 @@ $error_collector_mailto = '';
 
 $config = new config(CONFIG_DIR . '/' . CONFIG_FILE, $BASE_DIR);
 
+/* Enforce ssl if forced by gosa.conf */
+require_once __DIR__ . '/ssl_enforce.inc';
+enforce_ssl_if_forced();
+
 set_error_handler('gosaRaiseError', E_WARNING |  E_NOTICE | E_USER_ERROR | E_USER_WARNING | E_USER_NOTICE);
 
 $variables_order = 'ES';

--- a/include/ssl_enforce.inc
+++ b/include/ssl_enforce.inc
@@ -1,0 +1,65 @@
+
+<?php
+/**
+ * This code is part of GOsa (http://www.gosa-project.org)
+ * Copyright (C) 2003-2025 GONICUS GmbH
+ *
+ * ID: $$Id$$
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+function enforce_ssl_if_forced(): void
+{
+    global $config;
+
+    if (!$config) {
+        http_response_code(500);
+        echo "Configuration missing or invalid. Please contact the administrator.";
+        exit;
+    }
+
+    // if forceSSL in the gosa.conf is false, we can skip the ssl enforcement and return
+    if ($config->get_cfg_value('core', 'forceSSL') !== 'true') {
+        return;
+    }
+
+    // if the current request runs over https theres no need to redirect
+    if (is_https()) {
+        return;
+    }
+
+    $target = build_https_target();
+    header('Location: ' . $target, true, 302);
+    exit;
+}
+
+// detects if the current request runs over https
+function is_https(): bool {
+    if (!empty($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) === 'on') {
+        return true;
+    }
+    
+    return false;
+}
+
+// builds the target https url for redirecting
+function build_https_target(): string {
+    if (empty($_SERVER['REQUEST_URI'])) {
+        return 'https://' . $_SERVER['HTTP_HOST'] . $_SERVER['PATH_INFO'];
+    }
+    
+    return 'https://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+}


### PR DESCRIPTION
Fixes #40

In Issue #40, it was noted that (if  `forceSSL` is set to `true` in `gosa.conf`), the login/index.php page is only accessible via https, and a 302 response is received when communicating via HTTP. However, once logged in, other pages like `main.php` can also be accessed via http.

A test using Caddy, which was set up in a Docker container to establish http connections, confirmed the described scenario. The code responsible for checking whether the connection is via https and then responding with a 303 redirect if necessary was only found in `index.php` and `password.php`. However, since sensitive data, such as password changes, is also transmitted on pages like main.php, I have now moved the redirect code into an external include file, which is included and executed in `php_setup.inc`, so that https enforcement now takes place on every Gosa page, provided it is enabled.