### PR TITLE
Migrate from php 8.1 to php 8.4 + Bugfixes

### DIFF
--- a/html/getbin.php
+++ b/html/getbin.php
@@ -49,6 +49,6 @@ if (session::is_set('binaryfile')) {
 }
 
 echo session::get('binary');
-error_reporting (E_ALL | E_STRICT);
+error_reporting (E_ALL);
 
 ?>

--- a/html/helpviewer.php
+++ b/html/helpviewer.php
@@ -22,8 +22,8 @@
 
 /* Include classes and configs */
 require_once("../include/php_setup.inc");
-require_once("functions.inc");
-require_once("functions_helpviewer.inc");
+require_once("../include/functions.inc");
+require_once("../include/functions_helpviewer.inc");
 
 error_reporting(E_ALL);
 restore_error_handler();

--- a/html/helpviewer.php
+++ b/html/helpviewer.php
@@ -25,7 +25,7 @@ require_once("../include/php_setup.inc");
 require_once("functions.inc");
 require_once("functions_helpviewer.inc");
 
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 restore_error_handler();
 header("Content-type: text/html; charset=UTF-8");
 

--- a/html/helpviewer.php
+++ b/html/helpviewer.php
@@ -234,7 +234,7 @@ if (isset($_POST['search'])) {
     $header = "<!-- headers.tpl-->" . $smarty->fetch(get_template_path('headers.tpl'));
 
     /* I don't know why, but we must use utf8_encode to avoid dispplay errors */
-    $display = utf8_encode($header . $smarty->fetch(get_template_path('help.tpl')));
+    $display = mb_convert_encoding($header . $smarty->fetch(get_template_path('help.tpl')), 'UTF-8', 'ISO-8859-1');
     echo $display;
 } elseif ((is_dir($helpdir)) && ($fp = opendir($helpdir))) {
 
@@ -257,7 +257,7 @@ if (isset($_POST['search'])) {
     /* I don't know why, but we must use utf8_encode to avoid dispplay errors */
     $smarty->assign("backward", $back);
     $smarty->assign("forward", $for);
-    $display = utf8_encode($header . $smarty->fetch(get_template_path('help.tpl')));
+    $display = mb_convert_encoding($header . $smarty->fetch(get_template_path('help.tpl')), 'UTF-8', 'ISO-8859-1');
     echo $display;
 } else {
 

--- a/html/index.php
+++ b/html/index.php
@@ -23,10 +23,9 @@
 
 /* Load required includes */
 require_once "../include/php_setup.inc";
-require_once "functions.inc";
-require_once "class_log.inc";
+require_once "../include/functions.inc";
+require_once "../include/class_log.inc";
 header("Content-type: text/html; charset=UTF-8");
-
 
 /**
  * Display the login page and exit().
@@ -259,7 +258,7 @@ if (($_SERVER["REQUEST_METHOD"] == "POST" && isset($_POST['login'])) || $htacces
     /* Admin-logon and verify */
     $ldap = $config->get_ldap_link();
     if (is_null($ldap) || !($ldap instanceof ldapMultiplexer)) {
-        msg_dialog::display(_("LDAP error"), msgPool::ldaperror($ldap->get_error(), $_POST['login'], 0, __FILE__));
+        msg_dialog::display(_("LDAP error"), msgPool::ldaperror("Something went wrong while trying to get a ldap link object with get_ldap_link(). We incorrectly got null or an object of a different type as ldapMultiplexer.", $_POST['login'], 0, __FILE__));
         displayLogin();
         exit();
     }

--- a/html/index.php
+++ b/html/index.php
@@ -22,9 +22,9 @@
  */
 
 /* Load required includes */
-require_once "../include/php_setup.inc";
-require_once "../include/functions.inc";
-require_once "../include/class_log.inc";
+require_once("../include/php_setup.inc");
+require_once("../include/functions.inc");
+require_once("../include/class_log.inc");
 header("Content-type: text/html; charset=UTF-8");
 
 /**

--- a/html/logout.php
+++ b/html/logout.php
@@ -22,7 +22,7 @@
 
 /* Basic setup, remove eventually registered sessions */
 require_once("../include/php_setup.inc");
-require_once("functions.inc");
+require_once("../include/functions.inc");
 header("Content-type: text/html; charset=UTF-8");
 
 /* try to start session, so we can remove userlocks, 

--- a/html/password.php
+++ b/html/password.php
@@ -31,8 +31,8 @@ function displayPWchanger()
 }
 
 /* Load required includes */
-require_once "../include/php_setup.inc";
-require_once "../include/functions.inc";
+require_once("../include/php_setup.inc");
+require_once("../include/functions.inc");
 
 if (!class_exists("log")) {
     require_once("../include/class_log.inc");

--- a/html/password.php
+++ b/html/password.php
@@ -32,10 +32,10 @@ function displayPWchanger()
 
 /* Load required includes */
 require_once "../include/php_setup.inc";
-require_once "functions.inc";
+require_once "../include/functions.inc";
 
 if (!class_exists("log")) {
-    require_once("class_log.inc");
+    require_once("../include/class_log.inc");
 }
 
 header("Content-type: text/html; charset=UTF-8");

--- a/html/themes/default/js/eventListener.js
+++ b/html/themes/default/js/eventListener.js
@@ -86,7 +86,7 @@ let dp = document.querySelectorAll('.datepicker');
 let currentDate = new Date();
 let minDate = new Date(1920, 1, 1);
 let dateOptions = {
-    'format': 'dd mmm, yyyy',
+    'format': 'dd.mm.yyyy',
     'minDate': minDate,
     'maxDate': currentDate,
     'firstDay': 1,
@@ -95,6 +95,19 @@ let dateOptions = {
     'i18n': languages[lang]
 }
 var dpInstances = M.Datepicker.init(dp, dateOptions);
+
+let futureDp = document.querySelector('.futureDatepicker');
+let maxDate = new Date(3000, 1, 1);
+let futureDateOptions = {
+    'format': 'dd.mm.yyyy',
+    'minDate': currentDate,
+    'maxDate': maxDate,
+    'firstDay': 1,
+    'defaultDate': currentDate,
+    'yearRange': [currentDate.getFullYear(), maxDate.getFullYear()],
+    'i18n': languages[lang]
+}
+var futureDpInstances = M.Datepicker.init(futureDp, futureDateOptions);
 
 function language() {
     return language = {

--- a/include/class_SnapShotDialog.inc
+++ b/include/class_SnapShotDialog.inc
@@ -148,7 +148,7 @@ class SnapShotDialog extends plugin
                 $lData[$entry['dn']] = array('data' =>
                 array(
                     $time_stamp,
-                    htmlentities(utf8_decode(LDAP::fix($display_data))),
+                    htmlentities(mb_convert_encoding(LDAP::fix($display_data), 'ISO-8859-1', 'UTF-8')),
                     str_replace("%KEY", base64_encode($entry['dn']), $actions)
                 ));
             }

--- a/include/class_certificate.inc
+++ b/include/class_certificate.inc
@@ -32,6 +32,7 @@ class certificate
   var $data;
   var $type;
   var $error;
+  var $info;
 
   /* Initialize all vars*/ 
   function __construct()
@@ -95,7 +96,7 @@ class certificate
     }
 
     /* If cert is loaded correctly and is PEM now, we could read some data out of it */
-    if(count($this->info()) <=1)  {
+    if(is_countable($this->info()) && count($this->info()) <=1)  {
       $this->certificate();
       $this->error = _("Cannot load certificate: only PEM and DER are supported!");
       /* Reset*/
@@ -190,7 +191,7 @@ class certificate
 
   function isvalid()
   {
-    return (($this->type != false)&&(count($this->info)>1));
+    return (($this->type != false)&&is_countable($this->info())&&(count($this->info)>1));
   }
   
 

--- a/include/class_config.inc
+++ b/include/class_config.inc
@@ -88,8 +88,7 @@ class config
         // $this->parser = xml_parser_create();
         self::$parser = xml_parser_create();
         $this->basedir = $basedir;
-        xml_set_object(self::$parser, $this);
-        xml_set_element_handler(self::$parser, "tag_open", "tag_close");
+        xml_set_element_handler(self::$parser, [$this, 'tag_open'], [$this, 'tag_close']);
 
         /* Parse config file directly? */
         if ($filename != "") {
@@ -140,8 +139,7 @@ class config
             $this->section = "";
             $this->currentLocation = "";
 
-            xml_set_object(self::$parser, $this);
-            xml_set_element_handler(self::$parser, "tag_open", "tag_close");
+            xml_set_element_handler(self::$parser, [$this, 'tag_open'], [$this, 'tag_close']);
             $this->parse($this->filename);
             $this->set_current($this->current['NAME']);
         }

--- a/include/class_ldap.inc
+++ b/include/class_ldap.inc
@@ -1230,14 +1230,14 @@ class LDAP
         /* Reset index */
         $i = 1;
         $identifier = [];
-        $attribute = ldap_first_attribute(self::$cid, $entry, $identifier);
+        $attribute = ldap_first_attribute(self::$cid, $entry);
         while ($attribute) {
             $i++;
             $atts[$i]['name']  = $attribute;
             $atts[$i]['value'] = ldap_get_values_len(self::$cid, $entry, "$attribute");
 
             /* Next one */
-            $attribute = ldap_next_attribute(self::$cid, $entry, $identifier);
+            $attribute = ldap_next_attribute(self::$cid, $entry);
         }
 
         foreach ($atts as $at) {

--- a/include/class_stats.inc
+++ b/include/class_stats.inc
@@ -248,7 +248,7 @@ class stats
         foreach($category as $cat){
             $tmp[] = trim($cat, '\/,; ');
         }
-        $category = sqlite_escape_string(implode($tmp, ', '));
+        $category = sqlite_escape_string(implode(', ', $tmp));
 
         // Create insert statement.
         $TABLE_NAME = stats::$tableName;

--- a/include/class_userinfo.inc
+++ b/include/class_userinfo.inc
@@ -40,6 +40,7 @@ class userinfo
     var $ACLperPath = [];
     var $ACLperPath_usesFilter = [];
     var $allACLs = [];
+    var $password = null;
 
     /* get acl's an put them into the userinfo object
      attr subtreeACL (userdn:components, userdn:component1#sub1#sub2,component2,...) */

--- a/include/exporter/class_csvExporter.inc
+++ b/include/exporter/class_csvExporter.inc
@@ -27,7 +27,7 @@ class csvExporter
     foreach ($entries as $row) {
       foreach ($columns as $index) {
         if (isset($row["_sort$index"])){
-          $this->result.= trim(utf8_encode(html_entity_decode($row["_sort$index"]))).";";
+          $this->result.= trim(mb_convert_encoding(html_entity_decode($row["_sort$index"]), 'UTF-8', 'ISO-8859-1')).";";
         } else {
           $this->result.= ";";
         }

--- a/include/exporter/class_pdfExporter.inc
+++ b/include/exporter/class_pdfExporter.inc
@@ -31,7 +31,7 @@ class pdfExporter
     $this->result=new PDF('L', 'mm', 'A4');
     $this->result->AliasNbPages();
     $this->result->SetFont('Helvetica', '', 10);
-    $this->result->setHeadline(utf8_decode($headline));
+    $this->result->setHeadline(mb_convert_encoding($headline, 'ISO-8859-1', 'UTF-8'));
     $this->result->AddPage();
 
     // Analyze for width
@@ -56,7 +56,7 @@ class pdfExporter
 
         foreach ($columns as $order => $index) {
           if (isset($header[$index])){
-            $this->result->Cell($width[$order], 7, utf8_decode($header[$index]), 1, 0, 'C', 1);
+            $this->result->Cell($width[$order], 7, mb_convert_encoding($header[$index], 'ISO-8859-1', 'UTF-8'), 1, 0, 'C', 1);
           } else {
             $this->result->Cell($width[$order], 7, '', 1, 0, 'C', 1);
           }
@@ -72,7 +72,7 @@ class pdfExporter
       foreach ($columns as $order => $index) {
 
         if (isset($row["_sort$index"])){
-          $this->result->Cell($width[$order], 6, utf8_decode($row["_sort$index"]), 'LR', 0, 'L', $fill);
+          $this->result->Cell($width[$order], 6, mb_convert_encoding($row["_sort$index"], 'ISO-8859-1', 'UTF-8'), 'LR', 0, 'L', $fill);
         } else {
           $this->result->Cell($width[$order], 6, '', 'LR', 0, 'L', $fill);
         }

--- a/include/functions.inc
+++ b/include/functions.inc
@@ -2862,13 +2862,13 @@ function get_correct_class_name($cls)
  * for the object and it also takes care of sambaHashes, if enabled.
  * Finally the postmodify hook of the class 'user' will be called, if it is set.
  *
- * @param   String   The DN whose password shall be changed.
- * @param   String   The new password.
- * @param   Boolean  Skip adding samba hashes to the target (sambaNTPassword,sambaLMPassword)
- * @param   String   The hashin method to use, default is the global configured default.
- * @param   String   The users old password, this allows script based rollback mechanisms,
+ * @param   string   The DN whose password shall be changed.
+ * @param   string   The new password.
+ * @param   boolean  Skip adding samba hashes to the target (sambaNTPassword,sambaLMPassword)
+ * @param   string   The hashin method to use, default is the global configured default.
+ * @param   string   The users old password, this allows script based rollback mechanisms,
  *                    the prehook will then be called witch switched newPassword/oldPassword.
- * @return  Boolean  true on success else false.
+ * @return  boolean  true on success else false.
  */
 function change_password($dn, $password, $mode = false, $hash = '', $old_password = '', &$message = '')
 {
@@ -2993,6 +2993,9 @@ function change_password($dn, $password, $mode = false, $hash = '', $old_passwor
         // Perform ldap operations
         $ldap->modify($attrs);
 
+        $ldapModifySuccess = $ldap->success();
+        $ldapModifyGetError = $ldap->get_error();
+
         // Check if the object was locked before, if it was, lock it again!
         $deactivated = $test->is_locked($config, $dn);
         if ($deactivated) {
@@ -3004,13 +3007,12 @@ function change_password($dn, $password, $mode = false, $hash = '', $old_passwor
         $preRollback = false;
         $ldapRollback = false;
         $success = true;
-        if (!$ldap->success()) {
+        if (!$ldapModifySuccess) {
             new log("modify", "users/passwordMethod", $dn, [], "Password change - ldap modifications! - FAILED");
             $success = false;
-            $message = msgPool::ldaperror($ldap->get_error(), $dn, LDAP_MOD);
+            $message = msgPool::ldaperror($ldapModifyGetError, $dn, LDAP_MOD);
             $preRollback  = true;
         } else {
-
             // Now call the passwordMethod change mechanism.
             if (!$test->set_password($password)) {
                 $ldapRollback = true;
@@ -3091,6 +3093,8 @@ function change_password($dn, $password, $mode = false, $hash = '', $old_passwor
 
         return ($success);
     }
+
+    return False;
 }
 
 

--- a/include/functions.inc
+++ b/include/functions.inc
@@ -450,8 +450,8 @@ function gosa_log($message)
     /* Preset to something reasonable */
     $username = "[unauthenticated]";
 
-    /* Replace username if object is present */
-    if (isset($ui)) {
+    /* Replace username if object is present and not false */
+    if ($ui) {
         if ($ui->username != '') {
             $username = "[$ui->username]";
         } else {

--- a/include/functions_debug.inc
+++ b/include/functions_debug.inc
@@ -2,7 +2,7 @@
 /************************************************ 
 ** Title.........: Debug Lib
 ** Version.......: 0.5.4
-** Author........: Thomas Sch��ler <tulpe@atomar.de> 
+** Author........: Thomas Schüßler <tulpe@atomar.de> 
 ** Filename......: debuglib.php(s)
 ** Last changed..: 16. July 2003
 ** License.......: Free to use. Postcardware ;)
@@ -406,12 +406,12 @@ function show_vars($show_all_vars = FALSE, $show_object_vars = FALSE) {
 function pre($sql_string, $simple_mode = FALSE) {
 	
 	if(!$simple_mode) {
-		# erste leere Zeile im SQL l�schen
+		# erste leere Zeile im SQL löschen
 		$sql_string = preg_replace('/\^s+/m','', $sql_string);
-		# letze leere Zeile im SQL l�schen
+		# letze leere Zeile im SQL löschen
 		$sql_string = preg_replace('/\s+$/m','', $sql_string);
 		
-		# kleinste Anzahl von f�hrenden TABS z�hlen
+		# kleinste Anzahl von führenden TABS zählen
 		preg_match_all('/^\t+/m', $sql_string, $matches);
 		$minTabCount = strlen(min($matches[0]));
 		

--- a/include/functions_debug.inc
+++ b/include/functions_debug.inc
@@ -2,7 +2,7 @@
 /************************************************ 
 ** Title.........: Debug Lib
 ** Version.......: 0.5.4
-** Author........: Thomas Schüßler <tulpe@atomar.de> 
+** Author........: Thomas Schï¿½ï¿½ler <tulpe@atomar.de> 
 ** Filename......: debuglib.php(s)
 ** Last changed..: 16. July 2003
 ** License.......: Free to use. Postcardware ;)
@@ -297,7 +297,7 @@ function print_result($RESULT) {
 
 	mysqli_data_seek($RESULT, 0);
 
-	while($DB_ROW = mysqli_fetch_array($RESULT, MYSQL_NUM)) {
+	while($DB_ROW = mysqli_fetch_array($RESULT, MYSQLI_NUM)) {
 		$pointer++;
 		if($toggle) {
 			$col1 = "E6E6E6";
@@ -406,12 +406,12 @@ function show_vars($show_all_vars = FALSE, $show_object_vars = FALSE) {
 function pre($sql_string, $simple_mode = FALSE) {
 	
 	if(!$simple_mode) {
-		# erste leere Zeile im SQL löschen
+		# erste leere Zeile im SQL lï¿½schen
 		$sql_string = preg_replace('/\^s+/m','', $sql_string);
-		# letze leere Zeile im SQL löschen
+		# letze leere Zeile im SQL lï¿½schen
 		$sql_string = preg_replace('/\s+$/m','', $sql_string);
 		
-		# kleinste Anzahl von führenden TABS zählen
+		# kleinste Anzahl von fï¿½hrenden TABS zï¿½hlen
 		preg_match_all('/^\t+/m', $sql_string, $matches);
 		$minTabCount = strlen(min($matches[0]));
 		

--- a/include/functions_helpviewer.inc
+++ b/include/functions_helpviewer.inc
@@ -88,7 +88,7 @@ function genIndex()
       $str .= "<p style='padding-left:20px;'><b>"._($name)."</b> ("._("No help available for this plug-in.").")</p>";
     }
   }
-  return (utf8_decode($str));
+  return (mb_convert_encoding($str, 'ISO-8859-1', 'UTF-8'));
 }
 
 
@@ -452,7 +452,7 @@ function createResultEntry($entry,$res,$name,$max)
           <table summary=\"\"  width=\"98%\" align=\"center\">
             <tr>
               <td height=15>
-                <b>".utf8_encode($entry['headline'])."</b> -".utf8_encode(substr(strip_tags($entry['content']),0,120))."...
+                <b>".mb_convert_encoding($entry['headline'], 'UTF-8', 'ISO-8859-1')."</b> -".mb_convert_encoding(substr(strip_tags($entry['content']),0,120), 'UTF-8', 'ISO-8859-1')."...
               </td>
               <td width=50 valign=\"top\">".progressbar($percentage,50,8)."</td>
              </tr>

--- a/include/functions_helpviewer.inc
+++ b/include/functions_helpviewer.inc
@@ -31,8 +31,7 @@ class parseXml
   {
     $this->parser   = xml_parser_create();
     $this->filename = $file;
-    xml_set_object($this->parser, $this);
-    xml_set_element_handler($this->parser, "tag_open", "tag_close");
+    xml_set_element_handler(self::$parser, [$this, 'tag_open'], [$this, 'tag_close']);
     return($this->entries);
   }
   function parse()
@@ -277,7 +276,7 @@ function search($arr,$word)
   session::un_set('parsed_search_keyword');
   session::set('parsed_search_keyword',"");
 
-  error_reporting(E_ALL | E_STRICT);
+  error_reporting(E_ALL);
 
   /* prepare searchwords */
   $word   = trim($word);

--- a/include/functions_helpviewer.inc
+++ b/include/functions_helpviewer.inc
@@ -31,7 +31,7 @@ class parseXml
   {
     $this->parser   = xml_parser_create();
     $this->filename = $file;
-    xml_set_element_handler(self::$parser, [$this, 'tag_open'], [$this, 'tag_close']);
+    xml_set_element_handler($this->parser, [$this, 'tag_open'], [$this, 'tag_close']);
     return($this->entries);
   }
   function parse()

--- a/include/pChart/Example1.php
+++ b/include/pChart/Example1.php
@@ -4,8 +4,8 @@
  */
 
  // Standard inclusions      
- include("pChart/pData.class");   
- include("pChart/pChart.class");   
+ include("pData.class");   
+ include("pChart.class");   
   
  // Dataset definition    
  $DataSet = new pData;   
@@ -16,7 +16,7 @@
  $DataSet->SetSerieName("February","Serie2");   
  $DataSet->SetSerieName("March","Serie3");   
  $DataSet->SetYAxisName("Average age");
- $DataSet->SetYAxisUnit("µs");
+ $DataSet->SetYAxisUnit("ï¿½s");
   
  // Initialise the graph   
  $Test = new pChart(700,230);

--- a/include/pChart/Example1.php
+++ b/include/pChart/Example1.php
@@ -16,7 +16,7 @@
  $DataSet->SetSerieName("February","Serie2");   
  $DataSet->SetSerieName("March","Serie3");   
  $DataSet->SetYAxisName("Average age");
- $DataSet->SetYAxisUnit("�s");
+ $DataSet->SetYAxisUnit("µs");
   
  // Initialise the graph   
  $Test = new pChart(700,230);

--- a/include/pChart/Example10.php
+++ b/include/pChart/Example10.php
@@ -4,8 +4,8 @@
  */
 
  // Standard inclusions   
- include("pChart/pData.class");
- include("pChart/pChart.class");
+ include("pData.class");
+ include("pChart.class");
 
  // Dataset definition 
  $DataSet = new pData;

--- a/include/pChart/Example11.php
+++ b/include/pChart/Example11.php
@@ -4,8 +4,8 @@
  */
 
  // Standard inclusions   
- include("pChart/pData.class");
- include("pChart/pChart.class");
+ include("pData.class");
+ include("pChart.class");
  include("pChart/pCache.class");
 
  // Dataset definition 

--- a/include/pChart/Example12.php
+++ b/include/pChart/Example12.php
@@ -4,8 +4,8 @@
  */
 
  // Standard inclusions   
- include("pChart/pData.class");
- include("pChart/pChart.class");
+ include("pData.class");
+ include("pChart.class");
 
  // Dataset definition 
  $DataSet = new pData;

--- a/include/pChart/Example13.php
+++ b/include/pChart/Example13.php
@@ -4,8 +4,8 @@
  */
 
  // Standard inclusions   
- include("pChart/pData.class");
- include("pChart/pChart.class");
+ include("pData.class");
+ include("pChart.class");
 
  // Dataset definition 
  $DataSet = new pData;

--- a/include/pChart/Example14.php
+++ b/include/pChart/Example14.php
@@ -4,8 +4,8 @@
  */
 
  // Standard inclusions   
- include("pChart/pData.class");
- include("pChart/pChart.class");
+ include("pData.class");
+ include("pChart.class");
 
  // Dataset definition 
  $DataSet = new pData;

--- a/include/pChart/Example15.php
+++ b/include/pChart/Example15.php
@@ -4,8 +4,8 @@
  */
 
  // Standard inclusions      
- include("pChart/pData.class");   
- include("pChart/pChart.class");   
+ include("pData.class");   
+ include("pChart.class");   
   
  // Dataset definition    
  $DataSet = new pData;

--- a/include/pChart/Example16.php
+++ b/include/pChart/Example16.php
@@ -4,8 +4,8 @@
  */
 
  // Standard inclusions   
- include("pChart/pData.class");
- include("pChart/pChart.class");
+ include("pData.class");
+ include("pChart.class");
 
  // Dataset definition 
  $DataSet = new pData;

--- a/include/pChart/Example17.php
+++ b/include/pChart/Example17.php
@@ -4,8 +4,8 @@
  */
 
  // Standard inclusions
- include("pChart/pData.class");
- include("pChart/pChart.class");
+ include("pData.class");
+ include("pChart.class");
   
  // Dataset definition
  $DataSet = new pData;

--- a/include/pChart/Example18.php
+++ b/include/pChart/Example18.php
@@ -4,8 +4,8 @@
  */
 
  // Standard inclusions   
- include("pChart/pData.class");
- include("pChart/pChart.class");
+ include("pData.class");
+ include("pChart.class");
 
  // Dataset definition 
  $DataSet = new pData;

--- a/include/pChart/Example19.php
+++ b/include/pChart/Example19.php
@@ -4,8 +4,8 @@
  */
 
  // Standard inclusions   
- include("pChart/pData.class");
- include("pChart/pChart.class");
+ include("pData.class");
+ include("pChart.class");
 
  // Dataset definition 
  $DataSet = new pData;

--- a/include/pChart/Example2.php
+++ b/include/pChart/Example2.php
@@ -4,8 +4,8 @@
  */
 
  // Standard inclusions   
- include("pChart/pData.class");
- include("pChart/pChart.class");
+ include("pData.class");
+ include("pChart.class");
 
  // Dataset definition 
  $DataSet = new pData;

--- a/include/pChart/Example20.php
+++ b/include/pChart/Example20.php
@@ -4,8 +4,8 @@
  */
 
  // Standard inclusions   
- include("pChart/pData.class");
- include("pChart/pChart.class");
+ include("pData.class");
+ include("pChart.class");
 
  // Dataset definition 
  $DataSet = new pData;

--- a/include/pChart/Example21.php
+++ b/include/pChart/Example21.php
@@ -18,7 +18,7 @@
  $DataSet->SetSerieName("January","Serie1");
  $DataSet->SetSerieName("February","Serie2");
  $DataSet->SetYAxisName("Temperature");
- $DataSet->SetYAxisUnit("�C");
+ $DataSet->SetYAxisUnit("°C");
  $DataSet->SetXAxisUnit("h");
 
  // Initialise the graph

--- a/include/pChart/Example21.php
+++ b/include/pChart/Example21.php
@@ -4,8 +4,8 @@
  */
 
  // Standard inclusions   
- include("pChart/pData.class");
- include("pChart/pChart.class");
+ include("pData.class");
+ include("pChart.class");
 
  // Dataset definition 
  $DataSet = new pData;
@@ -18,7 +18,7 @@
  $DataSet->SetSerieName("January","Serie1");
  $DataSet->SetSerieName("February","Serie2");
  $DataSet->SetYAxisName("Temperature");
- $DataSet->SetYAxisUnit("°C");
+ $DataSet->SetYAxisUnit("ï¿½C");
  $DataSet->SetXAxisUnit("h");
 
  // Initialise the graph

--- a/include/pChart/Example22.php
+++ b/include/pChart/Example22.php
@@ -4,8 +4,8 @@
  */
 
  // Standard inclusions
- include("pChart/pData.class");
- include("pChart/pChart.class");
+ include("pData.class");
+ include("pChart.class");
   
  // Dataset definition
  $DataSet = new pData;

--- a/include/pChart/Example23.php
+++ b/include/pChart/Example23.php
@@ -18,7 +18,7 @@
  $DataSet->SetSerieName("January","Serie1");
  $DataSet->SetSerieName("February","Serie2");
  $DataSet->SetYAxisName("Temperature");
- $DataSet->SetYAxisUnit("�C");
+ $DataSet->SetYAxisUnit("°C");
  $DataSet->SetXAxisUnit("h");
 
  // Initialise the graph

--- a/include/pChart/Example23.php
+++ b/include/pChart/Example23.php
@@ -4,8 +4,8 @@
  */
 
  // Standard inclusions   
- include("pChart/pData.class");
- include("pChart/pChart.class");
+ include("pData.class");
+ include("pChart.class");
 
  // Dataset definition 
  $DataSet = new pData;
@@ -18,7 +18,7 @@
  $DataSet->SetSerieName("January","Serie1");
  $DataSet->SetSerieName("February","Serie2");
  $DataSet->SetYAxisName("Temperature");
- $DataSet->SetYAxisUnit("°C");
+ $DataSet->SetYAxisUnit("ï¿½C");
  $DataSet->SetXAxisUnit("h");
 
  // Initialise the graph

--- a/include/pChart/Example24.php
+++ b/include/pChart/Example24.php
@@ -4,8 +4,8 @@
  */
 
  // Standard inclusions   
- include("pChart/pData.class");
- include("pChart/pChart.class");
+ include("pData.class");
+ include("pChart.class");
 
  // Dataset definition 
  $DataSet = new pData;

--- a/include/pChart/Example25.php
+++ b/include/pChart/Example25.php
@@ -18,7 +18,7 @@
  $DataSet->SetSerieName("January","Serie1");
  $DataSet->SetSerieName("February","Serie2");
  $DataSet->SetYAxisName("Temperature");
- $DataSet->SetYAxisUnit("�C");
+ $DataSet->SetYAxisUnit("°C");
  $DataSet->SetXAxisUnit("h");
 
  // Initialise the graph

--- a/include/pChart/Example25.php
+++ b/include/pChart/Example25.php
@@ -4,8 +4,8 @@
  */
 
  // Standard inclusions   
- include("pChart/pData.class");
- include("pChart/pChart.class");
+ include("pData.class");
+ include("pChart.class");
 
  // Dataset definition 
  $DataSet = new pData;
@@ -18,7 +18,7 @@
  $DataSet->SetSerieName("January","Serie1");
  $DataSet->SetSerieName("February","Serie2");
  $DataSet->SetYAxisName("Temperature");
- $DataSet->SetYAxisUnit("°C");
+ $DataSet->SetYAxisUnit("ï¿½C");
  $DataSet->SetXAxisUnit("h");
 
  // Initialise the graph

--- a/include/pChart/Example26.php
+++ b/include/pChart/Example26.php
@@ -4,8 +4,8 @@
  */
 
  // Standard inclusions   
- include("pChart/pData.class");
- include("pChart/pChart.class");
+ include("pData.class");
+ include("pChart.class");
 
  // Dataset definition 
  $DataSet = new pData;

--- a/include/pChart/Example3.php
+++ b/include/pChart/Example3.php
@@ -4,8 +4,8 @@
  */
 
  // Standard inclusions   
- include("pChart/pData.class");
- include("pChart/pChart.class");
+ include("pData.class");
+ include("pChart.class");
 
  // Dataset definition 
  $DataSet = new pData;

--- a/include/pChart/Example4.php
+++ b/include/pChart/Example4.php
@@ -4,8 +4,8 @@
  */
 
  // Standard inclusions   
- include("pChart/pData.class");
- include("pChart/pChart.class");
+ include("pData.class");
+ include("pChart.class");
 
  // Dataset definition 
  $DataSet = new pData;

--- a/include/pChart/Example5.php
+++ b/include/pChart/Example5.php
@@ -4,8 +4,8 @@
  */
 
  // Standard inclusions   
- include("pChart/pData.class");
- include("pChart/pChart.class");
+ include("pData.class");
+ include("pChart.class");
 
  // Dataset definition 
  $DataSet = new pData;

--- a/include/pChart/Example6.php
+++ b/include/pChart/Example6.php
@@ -4,8 +4,8 @@
  */
 
  // Standard inclusions   
- include("pChart/pData.class");
- include("pChart/pChart.class");
+ include("pData.class");
+ include("pChart.class");
 
  // Dataset definition 
  $DataSet = new pData;

--- a/include/pChart/Example7.php
+++ b/include/pChart/Example7.php
@@ -4,8 +4,8 @@
  */
 
  // Standard inclusions   
- include("pChart/pData.class");
- include("pChart/pChart.class");
+ include("pData.class");
+ include("pChart.class");
 
  // Dataset definition 
  $DataSet = new pData;

--- a/include/pChart/Example8.php
+++ b/include/pChart/Example8.php
@@ -4,8 +4,8 @@
  */
 
  // Standard inclusions   
- include("pChart/pData.class");
- include("pChart/pChart.class");
+ include("pData.class");
+ include("pChart.class");
 
  // Dataset definition 
  $DataSet = new pData;

--- a/include/pChart/Example9.php
+++ b/include/pChart/Example9.php
@@ -4,8 +4,8 @@
  */
 
  // Standard inclusions   
- include("pChart/pData.class");
- include("pChart/pChart.class");
+ include("pData.class");
+ include("pChart.class");
 
  // Dataset definition 
  $DataSet = new pData;

--- a/include/pChart/HomePage3.php
+++ b/include/pChart/HomePage3.php
@@ -4,8 +4,8 @@
  */
 
  // Standard inclusions   
- include("pChart/pData.class");
- include("pChart/pChart.class");
+ include("pData.class");
+ include("pChart.class");
 
  // Dataset definition 
  $DataSet = new pData;
@@ -21,7 +21,7 @@
  $DataSet->SetSerieName("Gama","Serie3");
  $DataSet->SetXAxisName("Samples IDs");
  $DataSet->SetYAxisName("Test Marker");
- $DataSet->SetYAxisUnit("µm");
+ $DataSet->SetYAxisUnit("ï¿½m");
 
  // Initialise the graph
  $Test = new pChart(380,400);

--- a/include/pChart/HomePage3.php
+++ b/include/pChart/HomePage3.php
@@ -21,7 +21,7 @@
  $DataSet->SetSerieName("Gama","Serie3");
  $DataSet->SetXAxisName("Samples IDs");
  $DataSet->SetYAxisName("Test Marker");
- $DataSet->SetYAxisUnit("�m");
+ $DataSet->SetYAxisUnit("µm");
 
  // Initialise the graph
  $Test = new pChart(380,400);

--- a/include/pChart/Naked.php
+++ b/include/pChart/Naked.php
@@ -4,8 +4,8 @@
  */
 
  // Standard inclusions   
- include("pChart/pData.class");
- include("pChart/pChart.class");
+ include("pData.class");
+ include("pChart.class");
 
  // Dataset definition 
  $DataSet = new pData;

--- a/include/pChart/SmallGraph.php
+++ b/include/pChart/SmallGraph.php
@@ -4,8 +4,8 @@
  */
 
  // Standard inclusions   
- include("pChart/pData.class");
- include("pChart/pChart.class");
+ include("pData.class");
+ include("pChart.class");
 
  // Dataset definition 
  $DataSet = new pData;

--- a/include/pChart/SmallStacked.php
+++ b/include/pChart/SmallStacked.php
@@ -4,8 +4,8 @@
  */
 
  // Standard inclusions   
- include("pChart/pData.class");
- include("pChart/pChart.class");
+ include("pData.class");
+ include("pChart.class");
 
  // Dataset definition 
  $DataSet = new pData;
@@ -20,7 +20,7 @@
  $DataSet->SetSerieName("Beta","Serie2");
  $DataSet->SetSerieName("Gama","Serie3");
  $DataSet->SetYAxisName("Test Marker");
- $DataSet->SetYAxisUnit("µm");
+ $DataSet->SetYAxisUnit("ï¿½m");
 
  // Initialise the graph
  $Test = new pChart(210,230);

--- a/include/pChart/SmallStacked.php
+++ b/include/pChart/SmallStacked.php
@@ -20,7 +20,7 @@
  $DataSet->SetSerieName("Beta","Serie2");
  $DataSet->SetSerieName("Gama","Serie3");
  $DataSet->SetYAxisName("Test Marker");
- $DataSet->SetYAxisUnit("�m");
+ $DataSet->SetYAxisUnit("µm");
 
  // Initialise the graph
  $Test = new pChart(210,230);

--- a/include/password-methods/class_password-methods-sha.inc
+++ b/include/password-methods/class_password-methods-sha.inc
@@ -41,7 +41,7 @@ class passwordMethodsha extends passwordMethod
         if (function_exists('sha1')) {
             $hash = "{SHA}" . base64_encode(pack("H*", sha1($password)));
         } elseif (function_exists('mhash')) {
-            $hash = "{SHA}" . base64_encode(mHash(MHASH_SHA1, $password));
+            $hash = "{SHA}" . base64_encode(hash('sha1', $password, true));
         } else {
             msg_dialog::display(_("Configuration error"), msgPool::missingext("mhash"), ERROR_DIALOG);
             return false;

--- a/include/password-methods/class_password-methods-ssha.inc
+++ b/include/password-methods/class_password-methods-ssha.inc
@@ -41,14 +41,10 @@ class passwordMethodssha extends passwordMethod
             $salt = substr(pack("H*", sha1($salt . $pwd)), 0, 4);
             $pwd = "{SSHA}" . base64_encode(pack("H*", sha1($pwd . $salt)) . $salt);
             return $pwd;
-        } elseif (function_exists("mhash")) {
-            $salt = mhash_keygen_s2k(MHASH_SHA1, $pwd, substr(pack("h*", md5(mt_rand())), 0, 8), 4);
-            $pwd = "{SSHA}" . base64_encode(mhash(MHASH_SHA1, $pwd . $salt) . $salt);
         } else {
-            msg_dialog::display(_("Configuration error"), msgPool::missingext("mhash"), ERROR_DIALOG);
+            msg_dialog::display(_("Configuration error"), msgPool::missingext("sha1"), ERROR_DIALOG);
             return false;
         }
-        return $pwd;
     }
 
 

--- a/include/password-methods/class_password-methods.inc
+++ b/include/password-methods/class_password-methods.inc
@@ -384,7 +384,7 @@ class passwordMethod
 
         if ($config->boolValueIsTrue("core", "strictPasswordRules")) {
             // Do we have UTF8 characters in the password?
-            return ($password == utf8_decode($password));
+            return ($password == mb_convert_encoding($password, 'ISO-8859-1', 'UTF-8'));
         }
 
         return (true);

--- a/include/utils/class_msgPool.inc
+++ b/include/utils/class_msgPool.inc
@@ -375,7 +375,7 @@ class msgPool
     if ($depends == ""){
       return sprintf(_("This account has %s settings disabled. You can enable them by clicking below."), bold($name));
     } else {
-      if (count($depends) == 1){
+      if (!is_countable($depends) || count($depends) == 1){
         return sprintf(_("This account has %s settings disabled. To enable them, you'll need to add the %s settings first!"), bold($name), bold($depends));
       } else {
         $deps= "";

--- a/plugins/personal/generic/class_user.inc
+++ b/plugins/personal/generic/class_user.inc
@@ -1108,7 +1108,6 @@ class user extends plugin
 
                 $im = new Imagick();
                 $im->readImageBlob($this->photoData);
-                $im->setImageOpacity(1.0);
                 $im->resizeImage(147, 200, Imagick::FILTER_UNDEFINED, 0.5, TRUE);
                 $im->setCompressionQuality(90);
                 $im->setImageFormat('jpeg');

--- a/plugins/personal/generic/class_user.inc
+++ b/plugins/personal/generic/class_user.inc
@@ -361,7 +361,7 @@ class user extends plugin
         if (preg_match("/ editManager/i", " " . implode(' ', array_keys($_POST)) . " ")) {
             $this->dialog = new singleUserSelect($this->config, get_userinfo());
         }
-        if ($this->dialog && $this->dialog instanceof singleUserSelect && count($this->dialog->detectPostActions())) {
+        if ($this->dialog && $this->dialog instanceof singleUserSelect && count($this->dialog->detectPostActions() ?? [])) {
             $users = $this->dialog->detectPostActions();
             if (isset($users['action']) && $users['action'] == 'userSelected' && isset($users['targets']) && count($users['targets'])) {
                 $headpage = $this->dialog->getHeadpage();

--- a/plugins/personal/generic/default/generic.tpl
+++ b/plugins/personal/generic/default/generic.tpl
@@ -153,7 +153,7 @@
 
         {if $is_template ne "true" && !$multiple_support}
 
-        {render acl=$CertificatesACL mode=read_active}
+        {render acl=$CertificatesACL}
         <div class="input-field certificate">
             <button class="btn-small" id="edit_cert" type="submit" name="edit_cert">{t}Edit certificates{/t}...</button>
         </div>

--- a/plugins/personal/password/class_password.inc
+++ b/plugins/personal/password/class_password.inc
@@ -31,7 +31,7 @@ class password extends plugin
     var $proposalSelected = false;
     var $proposalInitialized = false;
 
-    var $forcedHash = null;
+    var $forcedHash = '';
     var $userPassword = '';
     var $attributes = array('userPassword');
 
@@ -226,7 +226,7 @@ class password extends plugin
                         _("You have no permission to change your password."),
                         WARNING_DIALOG
                     );
-                } elseif (!change_password($ui->dn, $new_password, false, $this->forcedHash, $current_password, $message)) {
+                } elseif (!change_password($ui->dn, $new_password, true, $this->forcedHash, $current_password, $message)) {
                     msg_dialog::display(
                         _("Password change"),
                         $message,
@@ -235,7 +235,7 @@ class password extends plugin
                 } else {
                     $ui->password = $new_password;
                     session::set('ui', $ui);
-                    return ($smarty->fetch(get_template_path("changed.tpl", true)));
+                    return ($smarty->fetch(get_template_path("changed.tpl", true, dirname(__FILE__))));
                 }
             }
             $smarty->assign("pwLength", $length);

--- a/plugins/personal/password/class_password.inc
+++ b/plugins/personal/password/class_password.inc
@@ -226,7 +226,7 @@ class password extends plugin
                         _("You have no permission to change your password."),
                         WARNING_DIALOG
                     );
-                } elseif (!change_password($ui->dn, $new_password, true, $this->forcedHash, $current_password, $message)) {
+                } elseif (!change_password($ui->dn, $new_password, false, $this->forcedHash, $current_password, $message)) {
                     msg_dialog::display(
                         _("Password change"),
                         $message,

--- a/plugins/personal/password/default/changed.tpl
+++ b/plugins/personal/password/default/changed.tpl
@@ -1,0 +1,12 @@
+<p>
+ <b>{t}You've successfully changed your password. Remember to change all programs configured to use it as well.{/t}</b>
+</p>
+
+<br>
+
+<hr>
+<div class="plugin-actions">
+  <button class="btn-small primary" type='submit' name='password_back'>{msgPool type=backButton}</button>
+</div>
+
+<input type="hidden" name="ignore">

--- a/plugins/personal/password/default/nochange.tpl
+++ b/plugins/personal/password/default/nochange.tpl
@@ -1,0 +1,11 @@
+<p>
+ <b>{t}You have no permission to change your password at this time{/t}</b>
+</p>
+
+<br>
+
+<hr>
+<div class="plugin-actions">
+  <button class="btn-small primary" type='submit' name='password_back'>{msgPool type=backButton}</button>
+</div>
+<input type="hidden" name="ignore">

--- a/plugins/personal/posix/class_posixAccount.inc
+++ b/plugins/personal/posix/class_posixAccount.inc
@@ -741,7 +741,7 @@ class posixAccount extends plugin
         } else {
             // Transform date to days since the beginning
             list($day, $month, $year) = explode('.', $this->shadowExpire, 3);
-            $this->shadowExpire = (int)(mktime(0, 0, 0, $month, $day, $year) / (60 * 60 * 24));
+            $this->shadowExpire = strval((int)(mktime(0, 0, 0, $month, $day, $year) / (60 * 60 * 24)));
         }
         if (!$this->activate_shadowMax) {
             $this->shadowMax = "0";
@@ -1712,7 +1712,7 @@ class posixAccount extends plugin
 
         /* Convert to seconds */
         if (isset($this->multi_attrs['shadowExpire'])) {
-            $this->shadowExpire = $this->convertToSeconds($this->multi_attrs['shadowExpire'][0]);
+            $this->shadowExpire = strval($this->convertToSeconds($this->multi_attrs['shadowExpire'][0]));
         } else {
             $this->activate_shadowExpire = FALSE;
         }

--- a/plugins/personal/posix/default/posix_shadow.tpl
+++ b/plugins/personal/posix/default/posix_shadow.tpl
@@ -49,7 +49,7 @@
         <span>{t}Password expires on{/t}
           {render acl=$shadowExpireACL}
           <input type="text" id="lang" value="{$lang}" hidden="true">
-          <input type="text" id="shadowExpire" name="shadowExpire" class="datepicker" style='width:100px'
+          <input type="text" id="shadowExpire" name="shadowExpire" class="futureDatepicker" style='width:100px'
             value="{$shadowExpire}">
           <i class="material-icons datepicker">edit_calendar</i>
           {/render}


### PR DESCRIPTION
Fixes following deprecations:
- E_STRICT
- utf8_encode() / utf8_decode()
- xml_set_handler(): Passing a non-callable string to handler
- implode(): old signature
- implicitly nullable parameters
- mhash()
- Creation of dynamic property
- MYSQL_NUM

Fixes following errors/bugs/warnings:
- wrong require paths
- called $ldap->get_error() on null
- wrong datepicker format (gosa expects dd.mm.yyyy)
- datepicker which only allowed selection of past dates was used where only future dates make sense
- passed uncountable arguments to count()
- passed identifier to ldap_first_attribute() which isnt used anymore
- fixed login warning when username was entered with uppercase/lowercase typos
- fixed documentation warnings
- ~~fixed changing password of current user~~ (I put this into another PR cause this need further discussion)
- fixed certificate import