### PR TITLE
Fix disappearing ogroups

### DIFF
--- a/include/class_ldap.inc
+++ b/include/class_ldap.inc
@@ -738,7 +738,7 @@ class LDAP
 
             /* Check if destination dn exists, if not the 
                server may not support this operation */
-            $r &= is_resource($this->dn_exists($dest));
+            $r = $r && ($this->dn_exists($dest) !== false);
             return ($r);
         } else {
             $this->error = 'Could not connect to LDAP server';

--- a/include/class_ldap.inc
+++ b/include/class_ldap.inc
@@ -736,10 +736,16 @@ class LDAP
             $r = ldap_rename(self::$cid, self::fix($source), self::fix($dest_rdn), self::fix($parent), true);
             $this->error = ldap_error(self::$cid);
 
-            /* Check if destination dn exists, if not the 
-               server may not support this operation */
-            $r = $r && ($this->dn_exists($dest) !== false);
-            return ($r);
+            if (!$r) {
+                return false;
+            }
+
+            if ($this->dn_exists($dest) === false) {
+                $this->error = "Destination DN '$dest' does not exist after ldap_rename.";
+                return false;
+            }
+
+            return true;
         } else {
             $this->error = 'Could not connect to LDAP server';
             return (false);

--- a/include/class_plugin.inc
+++ b/include/class_plugin.inc
@@ -979,7 +979,10 @@ abstract class plugin
         while ($attrs = $ldap->fetch()) {
             $src = $attrs['dn'];
             $dst = preg_replace("/" . preg_quote($src_dn, '/') . "$/", $dst_dn, $attrs['dn']);
-            $this->_copy($src, $dst);
+
+            if (!$this->_copy($src, $dst)) {
+                return (FALSE);
+            }
         }
         return (TRUE);
     }

--- a/include/class_plugin.inc
+++ b/include/class_plugin.inc
@@ -981,7 +981,7 @@ abstract class plugin
             $dst = preg_replace("/" . preg_quote($src_dn, '/') . "$/", $dst_dn, $attrs['dn']);
 
             if (!$this->_copy($src, $dst)) {
-                return (FALSE);
+                return false;
             }
         }
         return (TRUE);
@@ -1171,7 +1171,7 @@ abstract class plugin
                 "Move failed! Src or Dst DN is invalid.",
                 E_USER_WARNING
             );
-            return (FALSE);
+            return false;
         }
 
         /* Do not copy if only upper- lowercase has changed */

--- a/include/class_plugin.inc
+++ b/include/class_plugin.inc
@@ -1166,6 +1166,14 @@ abstract class plugin
     {
         global $config;
 
+        if (!is_valid_dn_syntax($src_dn) || !is_valid_dn_syntax($dst_dn)) {
+            trigger_error(
+                "Move failed! Src or Dst DN is invalid.",
+                E_USER_WARNING
+            );
+            return (FALSE);
+        }
+
         /* Do not copy if only upper- lowercase has changed */
         if (strtolower($src_dn) == strtolower($dst_dn)) {
             return (TRUE);

--- a/include/functions.inc
+++ b/include/functions.inc
@@ -4113,3 +4113,7 @@ function tempSwitch($arr)
             return $arr[0];
     }
 }
+
+function is_valid_dn_syntax($dn) {
+    return ldap_explode_dn($dn, 0) !== false;
+}

--- a/plugins/addons/propertyEditor/migration/class_migrateRDN.inc
+++ b/plugins/addons/propertyEditor/migration/class_migrateRDN.inc
@@ -199,7 +199,7 @@ class migrateRDN implements propertyMigration
             }
 
             // Now move the objects to the new traget
-            $tmp = new plugin($this->config, null);
+            $tmp = new class($this->config, null) extends plugin {};
             foreach ($this->found['move'] as $id => $data) {
                 if (isset($_POST["migrateEntry_{$id}"])) {
                     if ($tmp->move($data['from'], $data['to'])) {

--- a/plugins/admin/groups/class_group.inc
+++ b/plugins/admin/groups/class_group.inc
@@ -1087,7 +1087,7 @@ class group extends plugin
                 array(
                     "name"          => "ogroupRDN",
                     "type"          => "rdn",
-                    'default'       => "ou=ogroups,",
+                    'default'       => "ou=groups,",
                     'description'   => _("RDN for object group storage."),
                     "check"         => "gosaProperty::isRdn",
                     "migrate"       => "migrate_ogroupRDN",

--- a/plugins/admin/groups/class_group.inc
+++ b/plugins/admin/groups/class_group.inc
@@ -1087,7 +1087,7 @@ class group extends plugin
                 array(
                     "name"          => "ogroupRDN",
                     "type"          => "rdn",
-                    'DEFAULT'       => "ou=groups,",
+                    'default'       => "ou=groups,",
                     'description'   => _("RDN for object group storage."),
                     "check"         => "gosaProperty::isRdn",
                     "migrate"       => "migrate_ogroupRDN",

--- a/plugins/admin/groups/class_group.inc
+++ b/plugins/admin/groups/class_group.inc
@@ -1087,7 +1087,7 @@ class group extends plugin
                 array(
                     "name"          => "ogroupRDN",
                     "type"          => "rdn",
-                    'default'       => "ou=groups,",
+                    'default'       => "ou=ogroups,",
                     'description'   => _("RDN for object group storage."),
                     "check"         => "gosaProperty::isRdn",
                     "migrate"       => "migrate_ogroupRDN",

--- a/plugins/admin/ogroups/class_ogroup.inc
+++ b/plugins/admin/ogroups/class_ogroup.inc
@@ -133,7 +133,17 @@ class ogroup extends plugin
             $ui = get_userinfo();
             $this->base = dn2base(session::global_is_set("CurrentMainBase") ? "cn=dummy," . session::global_get("CurrentMainBase") : $ui->dn);
         } else {
-            $this->base = preg_replace("/^[^,]+," . preg_quote(get_ou("group", "ogroupRDN"), '/') . "/i", '', $this->dn);
+            $pattern = "/^[^,]+," . preg_quote(get_ou("group", "ogroupRDN"), '/') . "/i";
+            $computedBase = preg_replace($pattern, '', $this->dn);
+
+            // Fallback if the regex did not match. In this case we need to cut every attributes except dc and o to avoid setting the whole dn as base.
+            if ($computedBase === $this->dn) {
+                if (preg_match('/((dc|o)=[^,]+.*)$/i', $this->dn, $matches)) {
+                    $computedBase = $matches[1];
+                }
+            }
+
+            $this->base = $computedBase;
         }
 
         /* Detect all workstations, which are already assigned to an object group

--- a/plugins/admin/ogroups/class_ogroup.inc
+++ b/plugins/admin/ogroups/class_ogroup.inc
@@ -133,17 +133,7 @@ class ogroup extends plugin
             $ui = get_userinfo();
             $this->base = dn2base(session::global_is_set("CurrentMainBase") ? "cn=dummy," . session::global_get("CurrentMainBase") : $ui->dn);
         } else {
-            $pattern = "/^[^,]+," . preg_quote(get_ou("group", "ogroupRDN"), '/') . "/i";
-            $computedBase = preg_replace($pattern, '', $this->dn);
-
-            // Fallback if the regex did not match. In this case we need to cut every attributes except dc and o to avoid setting the whole dn as base.
-            if ($computedBase === $this->dn) {
-                if (preg_match('/((dc|o)=[^,]+.*)$/i', $this->dn, $matches)) {
-                    $computedBase = $matches[1];
-                }
-            }
-
-            $this->base = $computedBase;
+            $this->base = preg_replace("/^[^,]+," . preg_quote(get_ou("group", "ogroupRDN"), '/') . "/i", '', $this->dn);
         }
 
         /* Detect all workstations, which are already assigned to an object group


### PR DESCRIPTION
Fixes #75 

- Added default value for `ogroupRDN` (There was already a `'DEFAULT'` set but it wasnt working cause the correct array key is `'default'`)
- Propagate the boolean return val of _copy() in copy() to avoid calling
the rmdir_recursive() in move() although the previous copy() failed.
This avoids that entries like ogroups dissapear after calling move() 
- the return value of ldap_list() has changed from `resource` to `LDAP\Result` (see https://www.php.net/manual/en/function.ldap-list.php). For this reason I needed to change the way the return value was handled in `LDAP->rename_dn()`. Otherwise `rename_dn()` return false although the rename was succesfull
- After changing the ogroupRDN in the settings, the migration assistant is called. migrateRDN->save_object() tries to create a plugin object, which failed cause its an abstract class. Fixed it by creating a class which extends by plugin instead.
