### PR TITLE
Outsource frontend code from class_management, Fix bug that Apply and…

### DIFF
--- a/ihtml/themes/classic/tabFooter.tpl
+++ b/ihtml/themes/classic/tabFooter.tpl
@@ -1,0 +1,12 @@
+{if $readOnly}
+<p style='text-align:right'>
+    <button type='submit' name='edit_cancel'>{msgPool type=cancelButton}</button>
+</p>
+{else}
+<p style='text-align:right'>
+    <button type='submit' name='edit_finish'>{msgPool type=okButton}</button>
+    {if $displayApplyBtn}
+    <button type='submit' name='edit_apply'>{msgPool type=applyButton}</button>
+    {/if}
+    <button type='submit' name='edit_cancel'>{msgPool type=cancelButton}</button>
+{/if}

--- a/ihtml/themes/default/tabFooter.tpl
+++ b/ihtml/themes/default/tabFooter.tpl
@@ -1,0 +1,13 @@
+{if $readOnly}
+<div class='card-action'>
+    <button class='btn-small primary' type='submit' name='edit_cancel'>{msgPool type=cancelButton}</button>
+</div>
+{else}
+<div class='card-action'>
+    <button class='btn-small primary' type='submit' name='edit_finish'>{msgPool type=okButton}</button>
+    {if $displayApplyBtn}
+    <button class='btn-small primary' type='submit' name='edit_apply'>{msgPool type=applyButton}</button>
+    {/if}
+    <button class='btn-small primary' type='submit' name='edit_cancel'>{msgPool type=cancelButton}</button>
+</div>
+{/if}

--- a/include/class_management.inc
+++ b/include/class_management.inc
@@ -287,8 +287,6 @@ abstract class management
      */
     protected function _getTabFooter()
     {
-        $theme = getThemeName();
-
         // Do not display tab footer for non tab objects
         if (!($this->tabObject instanceof tabs || $this->tabObject instanceof multi_plug)) {
             return "";
@@ -307,53 +305,13 @@ abstract class management
             return "";
         }
 
-        if ($theme == "default") {
-            $acl_mode = preg_match("/^[r]$/", $this->ui->get_category_permissions($this->ui->dn, "users"));
-        }
+        $acl_mode = preg_match("/^[r]$/", $this->ui->get_category_permissions($this->ui->dn, "users"));
+        $readOnly = isset($this->tabObject->read_only) && $this->tabObject->read_only == true || $acl_mode;
 
-        // In case an of locked entry, we may have opened a read-only tab.
-        $str = "";
-        if (isset($this->tabObject->read_only) && $this->tabObject->read_only == true || $acl_mode) {
-            switch ($theme) {
-                case 'classic':
-                    $str .= "<p style=\"text-align:right\">
-                                <button type=submit name=\"edit_cancel\">" . msgPool::cancelButton() . "</button>
-                            </p>";
-                    break;
-
-                default:
-                    $str .= "<div class='card-action'>
-                                <button class='btn-small primary' type='submit' name='edit_cancel'>" . msgPool::cancelButton() . "</button>
-                            </div>";
-                    break;
-            }
-            return $str;
-        } else {
-
-            // Display ok, (apply) and cancel buttons
-            switch ($theme) {
-                case 'classic':
-                    $str .= "<p style=\"text-align:right\">
-                                <button type=\"submit\" name=\"edit_finish\">" . msgPool::okButton() . "</button>\n&nbsp;\n";
-                    if ($this->displayApplyBtn) {
-                        $str .= " <button type=\"submit\" name=\"edit_apply\">" . msgPool::applyButton() . "</button>&nbsp;\n";
-                    }
-                    $str .= "     <button type=\"submit\" name=\"edit_cancel\">" . msgPool::cancelButton() . "</button>
-                            </p>";
-                    break;
-
-                default:
-                    $str .= " <div class='card-action'>
-                                <button class='btn-small primary' type=\"submit\" name=\"edit_finish\">" . msgPool::okButton() . "</button>";
-                    if ($this->displayApplyBtn) {
-                        $str .= " <button class='btn-small primary' type=\"submit\" name=\"edit_apply\">" . msgPool::applyButton() . "</button>";
-                    }
-                    $str .= "     <button class='btn-small primary' type=\"submit\" name=\"edit_cancel\">" . msgPool::cancelButton() . "</button>
-                            </div>";
-                    break;
-            }
-        }
-        return $str;
+        $smarty = get_smarty();
+        $smarty->assign("readOnly", $readOnly);
+        $smarty->assign("displayApplyBtn", $this->displayApplyBtn);
+        return $smarty->fetch(get_template_path('tabFooter.tpl'));
     }
 
     /*! \brief  Initiates the removal for the given entries


### PR DESCRIPTION
Outsources the frontend code from the `class_management.inc` file to separate Smarty Templates `.../classic/tabFooter.tpl` and `.../default/tabFooter.tpl`.

Furthermore I removed the if clause `if ($theme == "default") { ... }` around `$acl_mode = preg_match("/^[r]$/", $this->ui->get_category_permissions($this->ui->dn, "users"));` cause i.m.o it doesnt make sense to set the $acl_mode exclusively for the default template. This results in a user with a Read only ACL still seeing the "OK" and "Apply" buttons in the classic template, even though he is not allowed to make any changes. Only for the default template, "OK" and "Apply" are not shown when the user only has read permissions, which is more ux friendly. With the current changes the behaviour is the same for both templates.