### PR TITLE
Outsource the frontend code from buildAclSelector to smarty templates

### DIFF
--- a/ihtml/themes/classic/aclSelector.tpl
+++ b/ihtml/themes/classic/aclSelector.tpl
@@ -1,23 +1,86 @@
 <input type='hidden' name='acl_dummy_0_0_0' value='1'>
-<button type='button' style='width:100px;' name='toggle_all_create' onClick="acl_toggle_all('_0_c$');" >Toggle C</button>
-<button type='button' style='width:100px;' name='toggle_all_move'   onClick="acl_toggle_all('_0_m$');" >Toggle M</button>
-<button type='button' style='width:100px;' name='toggle_all_remove' onClick="acl_toggle_all('_0_d$');" >Toggle D</button> - 
-<button type='button' style='width:100px;' name='toggle_all_read'   onClick="acl_toggle_all('_0_r$');" >Toggle R</button>
-<button type='button' style='width:100px;' name='toggle_all_write'  onClick="acl_toggle_all('_0_w$');" >Toggle W</button> - 
-<button type='button' style='width:100px;' name='toggle_all_sub_read'  onClick="acl_toggle_all('[^0]_r$');" >R+</button>
-<button type='button' style='width:100px;' name='toggle_all_sub_write'  onClick="acl_toggle_all('[^0]_w$');" >W+</button>
-<br>
-<button type='button' style='width:50px;' name='set_true_all_create' onClick="acl_set_all('_0_c$',true);" >C+</button>
-<button type='button' style='width:50px;' name='set_false_all_create' onClick="acl_set_all('_0_c$',false);" >C-</button>
-<button type='button' style='width:50px;' name='set_true_all_move' onClick="acl_set_all('_0_m$',true);" >M+</button>
-<button type='button' style='width:50px;' name='set_false_all_move' onClick="acl_set_all('_0_m$',false);" >M-</button>
-<button type='button' style='width:50px;' name='set_true_all_remove' onClick="acl_set_all('_0_d$',true);" >D+</button>
-<button type='button' style='width:50px;' name='set_false_all_remove' onClick="acl_set_all('_0_d$',false);" >D-</button> - 
-<button type='button' style='width:50px;' name='set_true_all_read' onClick="acl_set_all('_0_r$',true);" >R+</button>
-<button type='button' style='width:50px;' name='set_false_all_read' onClick="acl_set_all('_0_r$',false);" >R-</button>
-<button type='button' style='width:50px;' name='set_true_all_write' onClick="acl_set_all('_0_w$',true);" >W+</button>
-<button type='button' style='width:50px;' name='set_false_all_write' onClick="acl_set_all('_0_w$',false);" >W-</button> - 
-<button type='button' style='width:50px;' name='set_true_all_read' onClick="acl_set_all('[^0]_r$',true);" >R+</button>
-<button type='button' style='width:50px;' name='set_false_all_read' onClick="acl_set_all('[^0]_r$',false);" >R-</button>
-<button type='button' style='width:50px;' name='set_true_all_write' onClick="acl_set_all('[^0]_w$',true);" >W+</button>
-<button type='button' style='width:50px;' name='set_false_all_write' onClick="acl_set_all('[^0]_w$',false);" >W-</button>
+{foreach $aclObjects as $obj}
+    <table summary='{$obj.name}' style='width:100%;border:1px solid #A0A0A0' cellspacing=0 cellpadding=2>
+        <tr>
+            <td style='background-color:{if $obj.expand}#C8C8FF{else}#C8C8C8{/if};height:1.8em;' colspan=2>
+                <b>{t}Object{/t}: {$obj.name}</b>
+            </td>
+            <td align='right' style='background-color:{if $obj.expand}#C8C8FF{else}#C8C8C8{/if};height:1.8em;'>
+                {if $obj.splist}
+                    <button type='button' onclick="$('{$obj.tname}').toggle();">{t}Show/hide advanced settings{/t}</button>
+                {/if}
+            </td>
+        </tr>
+        <tr>
+            <td style='background-color:#E0E0E0' colspan=2>
+                {if $aclWriteable}
+                    <input id='acl_{$obj.tname}_0_c' type='checkbox' name='acl_{$obj.key}_0_c' {if $obj.overall.c}checked{/if}>
+                    <label for='acl_{$obj.tname}_0_c'>{t}Create objects{/t}</label>
+                    <input id='acl_{$obj.tname}_0_m' type='checkbox' name='acl_{$obj.key}_0_m' {if $obj.overall.m}checked{/if}>
+                    <label for='acl_{$obj.tname}_0_m'>{t}Move objects{/t}</label>
+                    <input id='acl_{$obj.tname}_0_d' type='checkbox' name='acl_{$obj.key}_0_d' {if $obj.overall.d}checked{/if}>
+                    <label for='acl_{$obj.tname}_0_d'>{t}Remove objects{/t}</label>
+                    {if $obj.selfModify}
+                        <input id='acl_{$obj.tname}_0_s' type='checkbox' name='acl_{$obj.key}_0_s' {if $obj.overall.s}checked{/if}>
+                        <label for='acl_{$obj.tname}_0_s'>{t}Restrict changes to user's own object{/t}</label>
+                    {/if}
+                {else}
+                    <input type='checkbox' disabled name='dummy_c' {if $obj.overall.c}checked{/if}>{t}Create objects{/t}
+                    <input type='checkbox' disabled name='dummy_m' {if $obj.overall.m}checked{/if}>{t}Move objects{/t}
+                    <input type='checkbox' disabled name='dummy_d' {if $obj.overall.d}checked{/if}>{t}Remove objects{/t}
+                    {if $obj.selfModify}
+                        <input type='checkbox' disabled name='dummy_s' {if $obj.overall.s}checked{/if}>{t}Restrict changes to user's own object{/t}
+                    {/if}
+                {/if}
+            </td>
+            <td style='background-color:#D4D4D4'>
+                &nbsp;{t}Complete object{/t}:
+                {if $aclWriteable}
+                    <input id='acl_{$obj.tname}_0_r' type='checkbox' name='acl_{$obj.key}_0_r' {if $obj.overall.r}checked{/if}>
+                    <label for='acl_{$obj.tname}_0_r'>{t}read{/t}</label>
+                    <input id='acl_{$obj.tname}_0_w' type='checkbox' name='acl_{$obj.key}_0_w' {if $obj.overall.w}checked{/if}>
+                    <label for='acl_{$obj.tname}_0_w'>{t}write{/t}</label>
+                {else}
+                    <input disabled type='checkbox' name='dummy_r' {if $obj.overall.r}checked{/if}>{t}read{/t}
+                    <input disabled type='checkbox' name='dummy_w' {if $obj.overall.w}checked{/if}>{t}write{/t}
+                {/if}
+            </td>
+        </tr>
+        <tr id='tr_{$obj.tname}' style='vertical-align:top;height:0px;'>
+            <td colspan=3>
+                <div id='{$obj.tname}' style='overflow:hidden; display:none;vertical-align:top;width:100%;'>
+                    <table style='width:100%;' summary='{$obj.name}'>
+                        {foreach $obj.attributes as $attr name=attr}
+                            {if $smarty.foreach.attr.iteration % 3 == 1}
+                                <tr>
+                            {/if}
+                            <td style='border-top:1px solid #A0A0A0;{if $smarty.foreach.attr.iteration % 3 != 0}border-right:1px solid #A0A0A0;{/if}width:33%'>
+                                <b>{$attr.dsc}</b> ({$attr.key})<br>
+                                {if $aclWriteable}
+                                    <input id='acl_{$obj.tname}_{$attr.key}_r' type='checkbox' name='acl_{$obj.key}_{$attr.key}_r' {if $attr.r}checked{/if}>
+                                    <label for='acl_{$obj.tname}_{$attr.key}_r'>{t}read{/t}</label>
+                                    <input id='acl_{$obj.tname}_{$attr.key}_w' type='checkbox' name='acl_{$obj.key}_{$attr.key}_w' {if $attr.w}checked{/if}>
+                                    <label for='acl_{$obj.tname}_{$attr.key}_w'>{t}write{/t}</label>
+                                {else}
+                                    <input disabled type='checkbox' name='dummy_r_{$attr.key}' {if $attr.r}checked{/if}>{t}read{/t}
+                                    <input disabled type='checkbox' name='dummy_w_{$attr.key}' {if $attr.w}checked{/if}>{t}write{/t}
+                                {/if}
+                            </td>
+                            {if $smarty.foreach.attr.iteration % 3 == 0 || $smarty.foreach.attr.last}
+                                {if $smarty.foreach.attr.last && $smarty.foreach.attr.iteration % 3 != 0}
+                                    {assign var=filled value=$smarty.foreach.attr.iteration % 3}
+                                    {assign var=missing value=3-$filled}
+                                    {section name=fill loop=$missing}
+                                        <td style='border-top:1px solid #A0A0A0;width:33%'>&nbsp;</td>
+                                    {/section}
+                                {/if}
+                                </tr>
+                            {/if}
+                        {/foreach}
+                    </table>
+                </div>
+            </td>
+        </tr>
+    </table>
+    <br/>
+{/foreach}

--- a/ihtml/themes/default/aclSelector.tpl
+++ b/ihtml/themes/default/aclSelector.tpl
@@ -1,0 +1,150 @@
+<input type='hidden' name='acl_dummy_0_0_0' value='1'>
+{foreach $aclObjects as $obj}
+    <div class='acl-object-wrapper'>
+        <div class='object-head-wrapper'>
+            <div class='object-name'>
+                {t}Object{/t}: {$obj.name}
+            </div>
+            {if $obj.splist}
+            <div class='advanced-settings'>
+                <button class='btn-extra-small' type='button' onclick="$('{$obj.tname}').toggle();">
+                    {t}Show/hide advanced settings{/t}
+                </button>
+            </div>
+            {/if}
+        </div>
+    <div class='object-body-wrapper'>
+        <div class='row'>
+            <div class='col s9 options'>
+                {if $aclWriteable}
+                    <label>
+                        <p>
+                            <input type='checkbox' id='acl_{$obj.tname}_0_c' name='acl_{$obj.key}_0_c' {if $obj.overall.c}checked{/if}>
+                            <span>{t}Create objects{/t}</span>
+                        </p>
+                    </label>
+                    <label>
+                        <p>
+                            <input type='checkbox' id='acl_{$obj.tname}_0_m' name='acl_{$obj.key}_0_m' {if $obj.overall.m}checked{/if}>
+                            <span>{t}Move objects{/t}</span>
+                        </p>
+                    </label>
+                    <label>
+                        <p>
+                            <input type='checkbox' id='acl_{$obj.tname}_0_d' name='acl_{$obj.key}_0_d' {if $obj.overall.d}checked{/if}>
+                            <span>{t}Remove objects{/t}</span>
+                        </p>
+                    </label>
+                    {if $obj.selfModify}
+                    <label>
+                        <p>
+                            <input type='checkbox' id='acl_{$obj.tname}_0_s' name='acl_{$obj.key}_0_s' {if $obj.overall.s}checked{/if}>
+                            <span>{t}Restrict changes to user's own object{/t}</span>
+                        </p>
+                    </label>
+                    {/if}
+                {else}
+                    <label>
+                        <p>
+                            <input type='checkbox' name='dummy_c' disabled {if $obj.overall.c}checked{/if}>
+                            <span>{t}Create objects{/t}</span>
+                        </p>
+                    </label>
+                    <label>
+                        <p>
+                            <input type='checkbox' name='dummy_m' disabled {if $obj.overall.m}checked{/if}>
+                            <span>{t}Move objects{/t}</span>
+                        </p>
+                    </label>
+                    <label>
+                        <p>
+                            <input type='checkbox' name='dummy_d' disabled {if $obj.overall.d}checked{/if}>
+                            <span>{t}Remove objects{/t}</span>
+                        </p>
+                    </label>
+                    {if $obj.selfModify}
+                    <label>
+                        <p>
+                            <input type='checkbox' name='dummy_s' disabled {if $obj.overall.s}checked{/if}>
+                            <span>{t}Restrict changes to user's own object{/t}</span>
+                        </p>
+                    </label>
+                    {/if}
+                {/if}
+            </div>
+            <div class='col s3 options'>
+                <span class='selection-label'>{t}Complete object{/t}:</span>
+                {if $aclWriteable}
+                    <label>
+                        <p>
+                            <input type='checkbox' id='acl_{$obj.tname}_0_r' name='acl_{$obj.key}_0_r' {if $obj.overall.r}checked{/if}>
+                            <span>{t}read{/t}</span>
+                        </p>
+                    </label>
+                    <label>
+                        <p>
+                            <input type='checkbox' id='acl_{$obj.tname}_0_w' name='acl_{$obj.key}_0_w' {if $obj.overall.w}checked{/if}>
+                            <span>{t}write{/t}</span>
+                        </p>
+                    </label>
+                {else}
+                    <label>
+                        <p>
+                            <input type='checkbox' name='dummy_r' disabled {if $obj.overall.r}checked{/if}>
+                            <span>{t}read{/t}</span>
+                        </p>
+                    </label>
+                    <label>
+                        <p>
+                            <input type='checkbox' name='dummy_w' disabled {if $obj.overall.w}checked{/if}>
+                            <span>{t}write{/t}</span>
+                        </p>
+                    </label>
+                {/if}
+            </div>
+        </div>
+    </div>
+    </div>
+    <div class='acl_container' id='{$obj.tname}' style='overflow:hidden; display:none;'>
+        <div class='row'>
+            {foreach $obj.attributes as $attr}
+            <div class='col s6 xl4'>
+                <div class='option-grp'>
+                    <div class='option-name'>
+                        {$attr.dsc} ({$attr.key})
+                    </div>
+                <div class='options'>
+                    {if $aclWriteable}
+                        <label>
+                            <p>
+                                <input type='checkbox' id='acl_{$obj.tname}_{$attr.key}_r' name='acl_{$obj.key}_{$attr.key}_r' {if $attr.r}checked{/if}>
+                                <span>{t}read{/t}</span>
+                            </p>
+                        </label>
+                        <label>
+                            <p>
+                                <input type='checkbox' id='acl_{$obj.tname}_{$attr.key}_w' name='acl_{$obj.key}_{$attr.key}_w' {if $attr.w}checked{/if}>
+                                <span>{t}write{/t}</span>
+                            </p>
+                        </label>
+                    {else}
+                        <label>
+                            <p>
+                                <input type='checkbox' name='dummy_r_{$attr.key}' disabled {if $attr.r}checked{/if}>
+                                <span>{t}read{/t}</span>
+                            </p>
+                        </label>
+                        <label>
+                            <p>
+                                <input type='checkbox' name='dummy_w_{$attr.key}' disabled {if $attr.w}checked{/if}>
+                                <span>{t}write{/t}</span>
+                            </p>
+                        </label>
+                    {/if}
+                </div>
+            </div>
+        </div>
+            {/foreach}
+        </div>
+    </div>
+{/foreach}

--- a/include/class_acl.inc
+++ b/include/class_acl.inc
@@ -894,24 +894,19 @@ class acl extends plugin
     function buildAclSelector($list)
     {
         global $smarty;
-        $display = "<input type='hidden' name='acl_dummy_0_0_0' value='1'>";
-        $cols = 3;
         $tmp = session::global_get('plist');
         $plist = $tmp->info;
         asort($plist);
 
-        if ($this->acl_is_writeable("")) {
-            $smarty->fetch(get_template_path('aclSelector.tpl'));
-        }
-
         /* Build general objects */
         $list = $this->sort_by_priority($list);
+
+        $aclObjects = [];
 
         //$list contains the available category with an name e.g.: departement/institute
         //$key is eg: "departement/institute" and $name is: "Institute"
         foreach ($list as $key => $name) {
             /* Walk through the list of attributes */
-            $cnt = 1;
             $splist = [];
             $t_key = preg_replace('%^.*/%', '', $key);
             if (isset($plist[$t_key]['plProvidedAcls'])) {
@@ -932,296 +927,46 @@ class acl extends plugin
 
             /* Object header */
             $tname = preg_replace("/[^a-z0-9]/i", "_", $name);
-
-            if ($expand) {
-                $back_color = "#C8C8FF";
-            } else {
-                $back_color = "#C8C8C8";
-            }
-
-            if (
-                isset($_SERVER['HTTP_USER_AGENT']) &&
-                (preg_match("/gecko/i", $_SERVER['HTTP_USER_AGENT'])) ||
-                (preg_match("/presto/i", $_SERVER['HTTP_USER_AGENT']))
-            ) {
-
-                switch ($this->theme) {
-                    case 'classic':
-                        $display .= "<table summary='{$name}' style='width:100%;border:1px solid #A0A0A0' cellspacing=0 cellpadding=2>
-                                <tr>
-                                    <td style='background-color:{$back_color};height:1.8em;' colspan=" . ($cols - 1) . "><b>" . _("Object") . ": $name</b></td>
-                                    <td align='right' style='background-color:{$back_color};height:1.8em;'>
-                                        <button type='button' onclick=\"$('{$tname}').toggle();\">" . _("Show/hide advanced settings") . "</button>
-                                    </td>
-                                </tr>";
-                        break;
-                    default:
-                        $display .= "   <div class='acl-object-wrapper'>
-                                            <div class='object-head-wrapper'>
-                                                <div class='object-name'>
-                                                    " . _("Object") . ": $name
-                                                </div>";
-                        if ($splist) {
-                            $display .= "   <div class='advanced-settings'>
-                                                <button class='btn-extra-small' type='button' onclick=\"$('{$tname}').toggle();\">
-                                                    " . _("Show/hide advanced settings") . "
-                                                </button>
-                                            </div>";
-                        }
-                        $display .= "   </div>";
-                        break;
-                }
-            } else {
-                switch ($this->theme) {
-                    case 'classic':
-                        $display .= "   <table summary='{$name}' style='width:100%;border:1px solid #A0A0A0' cellspacing=0 cellpadding=2>
-                                            <tr>
-                                                <td style='background-color:#C8C8C8;height:1.8em;' colspan=$cols>
-                                                    <b>" . _("Object") . ": $name</b>
-                                                </td>
-                                            </tr>";
-                        break;
-                    default:
-                        $display .= "   <div class='acl-object-wrapper'>
-                                            <div class='object-head-wrapper'>
-                                                <div class='object-name'>
-                                                    " . _("Object") . ": $name
-                                                </div>
-                                            </div>";
-                        break;
-                }
-            }
-
-            /* Generate options */
-            $options = $this->mkchkbx($key . "_0_c",  _("Create objects"), preg_match('/c/', $overall_acl));
-            $options .= $this->mkchkbx($key . "_0_m", _("Move objects"), preg_match('/m/', $overall_acl));
-            $options .= $this->mkchkbx($key . "_0_d", _("Remove objects"), preg_match('/d/', $overall_acl));
-            if ($plist[preg_replace('%^.*/%', '', $key)]['plSelfModify']) {
-                $options .= $this->mkchkbx($key . "_0_s", _("Restrict changes to user's own object"), preg_match('/s/', $overall_acl));
-            }
-
-            /* Global options */
-            $more_options = $this->mkchkbx($key . "_0_r",  _("read"), preg_match('/r/', $overall_acl));
-            $more_options .= $this->mkchkbx($key . "_0_w", _("write"), preg_match('/w/', $overall_acl));
-
-            switch ($this->theme) {
-                case 'classic':
-                    $display .= "   <tr>
-                                        <td style='background-color:#E0E0E0' colspan=" . ($cols - 1) . ">$options</td>
-                                        <td style='background-color:#D4D4D4'>&nbsp;" . _("Complete object") . ": $more_options</td>
-                                    </tr>";
-                    break;
-                default:
-                    $display .= "   <div class='object-body-wrapper'>
-                                        <div class='row'>
-                                            <div class='col s9 options'>$options</div>
-                                            <div class='col s3 options'>
-                                                <span class='selection-label'>" . _("Complete object") . ":</span> $more_options
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>";
-                    break;
-            }
-
-
-            switch ($this->theme) {
-                case 'classic':
-                    $display .= "   <tr id='tr_$tname' style='vertical-align:top;height:0px;'>
-                                                <td colspan=" . $cols . ">
-                                                    <div id='$tname' style='overflow:hidden; display:none;vertical-align:top;width:100%;'>
-                                                        <table style='width:100%;' summary='{$name}'>";
-                    break;
-                default:
-                    $display .= "   <div class='acl_container' id='$tname' style='overflow:hidden; display:none;'>
-                                                <div class='row'>";
-                    break;
-            }
-
+        
+            $attributes = [];
             foreach ($splist as $attr => $dsc) {
-                /* Skip pl* attributes, they are internal... */
-                if (preg_match('/^pl[A-Z]+.*$/', $attr)) {
+                if (preg_match('/^pl[A-Z]+.*$/', $attr))  {
                     continue;
                 }
-
-                /* Open table row */
-                if ($cnt == 1) {
-                    switch ($this->theme) {
-                        case 'classic':
-                            $display .= '<tr>';
-                            break;
-
-                        default:
-                            break;
-                    }
-                }
-
-                // initialize end tag since it may be used uninitialized later
-                $end = '';
-
-                /* Close table row */
-                switch ($this->theme) {
-                    case 'classic':
-                        if ($cnt == $cols) {
-                            $cnt = 1;
-                            $rb = "";
-                            $end = "</tr>";
-                        } else {
-                            $cnt++;
-                            $rb = "border-right:1px solid #A0A0A0;";
-                            $end = "";
-                        }
-                        break;
-                    default:
-                        break;
-                }
-
-                /* Collect list of attributes */
-                $state = "";
-                if (isset($currentAcl[$attr])) {
-                    $state = $currentAcl[$attr];
-                }
-
-                switch ($this->theme) {
-                    case 'classic':
-                        $display .= "   <td style='border-top:1px solid #A0A0A0;{$rb}width:" . (int)(100 / $cols) . "%'>
-                                            <b>$dsc</b> ($attr)<br>" . $this->mkrwbx($key . "_" . $attr, $state) . "
-                                        </td>$end";
-                        break;
-                    default:
-                        $display .= "   <div class='col s6 xl" . (12 / $cols) . "'>
-                                            <div class='option-grp'>
-                                                <div class='option-name'>
-                                                    $dsc ($attr)
-                                                </div>
-                                            <div class='options'>
-                                                " . $this->mkrwbx($key . "_" . $attr, $state) . "
-                                            </div>
-                                        </div>
-                                    </div>$end";
-                        break;
-                }
+                $state = $currentAcl[$attr] ?? "";
+                $attributes[$attr] = [
+                    'key' => $attr,
+                    'dsc' => $dsc,
+                    'state' => $state,
+                    'r' => preg_match('/r/', $state),
+                    'w' => preg_match('/w/', $state),
+                ];
             }
 
-            /* Fill missing td's if needed */
-            if (--$cnt != $cols && $cnt != 0) {
-                $display .= str_repeat("\n    <td style='border-top:1px solid #A0A0A0; width:" . (int)(100 / $cols) . "%'>&nbsp;</td>", $cols - $cnt);
-            }
-
-            if (session::global_get('js')) {
-                if (
-                    isset($_SERVER['HTTP_USER_AGENT']) &&
-                    (preg_match("/gecko/i", $_SERVER['HTTP_USER_AGENT'])) ||
-                    (preg_match("/presto/i", $_SERVER['HTTP_USER_AGENT'])) ||
-                    (preg_match("/ie/i", $_SERVER['HTTP_USER_AGENT']))
-                ) {
-                    switch ($this->theme) {
-                        case 'classic':
-                            $display .= "   </table>
-                                        </div>
-                                    </td>
-                                </tr>";
-                            break;
-                        default:
-                            $display .= "   </div>
-                                        </div>";
-                            break;
-                    }
-                }
-            }
-            switch ($this->theme) {
-                case 'classic':
-                    $display .= "</table><br/>";
-                    break;
-
-                default:
-                    break;
-            }
+            $aclObjects[$key] = [
+                'key'  => $key,
+                'name' => $name,
+                'tname' => $tname,
+                'expand' => $expand,
+                'splist' => $splist,
+                'overall' => [
+                    'c' => preg_match('/c/', $overall_acl),
+                    'm' => preg_match('/m/', $overall_acl),
+                    'd' => preg_match('/d/', $overall_acl),
+                    's' => $plist[$t_key]['plSelfModify'] ? preg_match('/s/', $overall_acl) : 0,
+                    'r' => preg_match('/r/', $overall_acl),
+                    'w' => preg_match('/w/', $overall_acl),
+                ],
+                'attributes' => $attributes,
+                'js' => session::global_get('js'),
+                'selfModify' => !empty($plist[$t_key]['plSelfModify'])
+            ];
         }
 
-        return ($display);
-    }
-
-    function mkchkbx($name, $text, $state = FALSE)
-    {
-        $state = $state ? "checked" : "";
-        if ($this->acl_is_writeable("")) {
-            $tname = preg_replace("/[^a-z0-9]/i", "_", $name);
-            switch ($this->theme) {
-                case 'classic':
-                    return "<input id='acl_$tname' type='checkbox' name='acl_$name' $state>
-                            <label for='acl_$tname'>$text</label>";
-                default:
-                    return "<label>
-                                <p>
-                                    <input type='checkbox' id='acl_$tname' name='acl_$name' $state>
-                                    <span>$text</span>
-                                </p>
-                            </label>";
-            }
-        } else {
-            switch ($this->theme) {
-                case 'classic':
-                    return "<input type='checkbox' disabled name='dummy_" . microtime(1) . "' $state>$text";
-                default:
-                    return "<label>
-                                <p>
-                                    <input type='checkbox' name='dummy_" . microtime(1) . "' disabled $state>
-                                    <span>$text</span>
-                                </p>
-                            </label>";
-                    break;
-            }
-        }
-    }
-
-    function mkrwbx($name, $state = "")
-    {
-        $rstate = preg_match('/r/', $state) ? 'checked' : '';
-        $wstate = preg_match('/w/', $state) ? 'checked' : '';
-        $tname = preg_replace("/[^a-z0-9]/i", "_", $name);
-
-        if ($this->acl_is_writeable("")) {
-            switch ($this->theme) {
-                case 'classic':
-                    return "<input id='acl_" . $tname . "_r' type='checkbox' name='acl_{$name}_r' $rstate>
-                            <label for='acl_" . $tname . "_r'>" . _("read") . "</label>
-                            <input id='acl_" . $tname . "_w' type='checkbox' name='acl_{$name}_w' $wstate>
-                            <label for='acl_" . $tname . "_w'>" . _("write") . "</label>";
-                default:
-                    return "<label>
-                                <p>
-                                    <input type='checkbox' id='acl_" . $tname . "_r' name='acl_{$name}_r' $rstate>
-                                    <span>" . _("read") . "</span>
-                                </p>
-                            </label>
-                            <label>
-                                <p>
-                                    <input type='checkbox' id='acl_" . $tname . "_w' name='acl_{$name}_w' $wstate>
-                                    <span>" . _("write") . "</span>
-                                </p>
-                            </label>";
-            }
-        } else {
-            switch ($this->theme) {
-                case 'classic':
-                    return "<input disabled type=checkbox name='dummy_" . microtime(1) . "' $rstate>" . _("read") . "
-                            <input disabled type=checkbox name='dummy_" . microtime(1) . "' $wstate>" . _("write");
-                default:
-                    return "<label>
-                                <p>
-                                    <input type='checkbox' name='dummy_" . microtime(1) . "' disabled $rstate>
-                                    <span>" . _("read") . "</span>
-                                </p>
-                            </label>
-                            <label>
-                                <p>
-                                    <input type='checkbox' name='dummy_" . microtime(1) . "' disabled $wstate>
-                                    <span>" . _("write") . "</span>
-                                </p>
-                            </label>";
-            }
-        }
+        $smarty = get_smarty();
+        $smarty->assign('aclObjects', $aclObjects);
+        $smarty->assign('aclWriteable', $this->acl_is_writeable(""));
+        return $smarty->fetch(get_template_path('aclSelector.tpl'));
     }
 
     /**


### PR DESCRIPTION
Before:
- buildAclSelector() processed information about the acl's (tname, splist, ...) and then used to generate the frontend

After:
- buildAclSelector() still processes the information about the acl's but then passes them as an `aclObjects` array to the smarty templates to separete backend logic and frontend code

Additional notes:
- The current `aclSelector.tpl` files are not used, so I replaced the content (the one for default template was already empty) with the new template code
- Removed outdated gecko / presto / ie browser recognition checks
- mkchkbx(), mkrwbx() are no longer needed, cause the boxes are now defined within the smarty templates and the functions were only used in the buildAclSelector()