### PR TITLE
Fix/add debian shadow expire patches

### DIFF
--- a/plugins/personal/posix/class_posixAccount.inc
+++ b/plugins/personal/posix/class_posixAccount.inc
@@ -242,14 +242,14 @@ class posixAccount extends plugin
             ) as $val
         ) {
 
-            if ($this->$val != 0) {
+            if ($this->$val != 0 && $this->$val !== "") {
                 $oval = "activate_" . $val;
                 $this->$oval = "1";
             }
         }
 
         /* Convert shadowExpire for usage */
-        if ($this->shadowExpire == 0) {
+        if ($this->shadowExpire == 0 || $this->shadowExpire == "") {
             $this->shadowExpire = '';
         } else {
             $this->shadowExpire = date('d.m.Y', intval($this->shadowExpire) * 60 * 60 * 24);
@@ -909,6 +909,10 @@ class posixAccount extends plugin
         }
 
         foreach (array("shadowMin", "shadowMax", "shadowWarning", "shadowInactive", "shadowExpire") as $attr) {
+            if (is_string($this->$attr) && empty($this->$attr)) {
+                continue;
+            }
+
             $this->$attr = (int) $this->$attr;
         }
         /* Call parents save to prepare $this->attrs */
@@ -1263,7 +1267,7 @@ class posixAccount extends plugin
                 "shadowExpire"
             ) as $val
         ) {
-            if ($this->$val != 0) {
+            if ($this->$val != 0 && $this->$val !== "") {
                 $oval = "activate_" . $val;
                 $this->$oval = "1";
             }
@@ -1275,7 +1279,7 @@ class posixAccount extends plugin
         }
 
         /* Convert shadowExpire for usage */
-        if ($this->shadowExpire == 0) {
+        if ($this->shadowExpire == 0 || $this->shadowExpire == "") {
             $this->shadowExpire = '';
         } else {
             $this->shadowExpire = date('d.m.Y', $this->shadowExpire * 60 * 60 * 24);
@@ -1458,14 +1462,14 @@ class posixAccount extends plugin
             ) as $val
         ) {
 
-            if ($this->$val != 0) {
+            if ($this->$val != 0 && $this->$val !== "") {
                 $oval = "activate_" . $val;
                 $this->$oval = "1";
             }
         }
 
         /* Convert shadowExpire for usage */
-        if ($this->shadowExpire == 0) {
+        if ($this->shadowExpire == 0 || $this->shadowExpire == "") {
             $this->shadowExpire = '';
         } else {
             $this->shadowExpire = date('d.m.Y', $this->shadowExpire * 60 * 60 * 24);
@@ -1704,7 +1708,7 @@ class posixAccount extends plugin
                 "shadowExpire"
             ) as $val
         ) {
-            if ($this->$val != 0) {
+            if ($this->$val != 0 && $this->$val !== "") {
                 $oval = "activate_" . $val;
                 $this->$oval = "1";
             }

--- a/plugins/personal/posix/classic/posix_shadow.tpl
+++ b/plugins/personal/posix/classic/posix_shadow.tpl
@@ -58,10 +58,10 @@
 
     <table summary="{t}Password expiration settings{/t}" border="0" cellpadding="0" cellspacing="0">
      <tr>
-      <td>
+      <td style="vertical-align:middle">
        {t}Password expires on{/t}&nbsp;
       </td>
-      <td style='width:125px'>
+      <td style='width:200px'>
 
        {render acl=$shadowExpireACL}
         <input type="text" id="shadowExpire" name="shadowExpire" class="date" style='width:100px' value="{$shadowExpire}">

--- a/plugins/personal/posix/posix_shadow.tpl
+++ b/plugins/personal/posix/posix_shadow.tpl
@@ -58,10 +58,10 @@
 
     <table summary="{t}Password expiration settings{/t}" border="0" cellpadding="0" cellspacing="0">
      <tr>
-      <td>
+      <td style="vertical-align:middle">
        {t}Password expires on{/t}&nbsp;
       </td>
-      <td style='width:125px'>
+      <td style='width:200px'>
 
        {render acl=$shadowExpireACL}
         <input type="text" id="shadowExpire" name="shadowExpire" class="date" style='width:100px' value="{$shadowExpire}">


### PR DESCRIPTION
I noticed that the shadowExpire checkbox is behaving strangely. E.g. when creating a template with disabled shadowExpire and then creating a user out of the template, the checkbox is suddenly enabled. I discovered a corresponding patch in the debian patches from Issue #61

[1045_fix-posixaccount-shadowExpire.patch](https://salsa.debian.org/debian-edu-pkg-team/gosa/-/blob/master/debian/patches/1045_fix-posixaccount-shadowExpire.patch?ref_type=heads) ensures that if `shadowExpire` is received as an empty string, `activate_shadowExpire` is not incorrectly set to "1". This fixes the aforementioned problem.

I also added the patch [1138_shadowexpire_in_one_line.patch](https://salsa.debian.org/debian-edu-pkg-team/gosa/-/blob/master/debian/patches/1138_shadowexpire_in_one_line.patch) so that the calendar button in the classic template appears next to the text field, just like in the default template.