### PR TITLE
Fix wrong value for smarty template department input field

### DIFF
--- a/plugins/personal/generic/default/generic.tpl
+++ b/plugins/personal/generic/default/generic.tpl
@@ -224,7 +224,7 @@
 
         {render acl=$ouACL checkbox=$multiple_support checked=$use_ou}
         <div class="input-field">
-            <input type="text" id="ou" name="ou" maxlength=60 value="{$o}">
+            <input type="text" id="ou" name="ou" maxlength=60 value="{$ou}">
             <label for="ou">{t}Department{/t}</label>
         </div>
         {/render}


### PR DESCRIPTION
Jan found the error. The value of the department field was incorrectly set to 'o' instead of 'ou'.