### PR TITLE
Fix ACL saving

### DIFF
--- a/include/class_acl.inc
+++ b/include/class_acl.inc
@@ -474,7 +474,7 @@ class acl extends plugin
             }
 
             /* Save new acl in case of base edit mode */
-            if ($this->acl_type == 'base' && !$firstedit && !empty($new_acl) && !$aclDialog) {
+            if ($this->acl_type == 'base' && !$firstedit && !empty($new_acl) && $this->aclObject == "") {
                 $this->aclContents = $new_acl;
 
                 if ($this->currentIndex != null && isset($this->gosaAclEntry[$this->currentIndex])) {

--- a/include/class_acl.inc
+++ b/include/class_acl.inc
@@ -474,7 +474,7 @@ class acl extends plugin
             }
 
             /* Save new acl in case of base edit mode */
-            if ($this->acl_type == 'base' && !$firstedit && !empty($new_acl) && $this->aclObject == "") {
+            if ($this->acl_type == 'base' && !$firstedit && !empty($new_acl)) {
                 $this->aclContents = $new_acl;
 
                 if ($this->currentIndex != null && isset($this->gosaAclEntry[$this->currentIndex])) {


### PR DESCRIPTION
The additional `!$aclDialog` condition breaks the functionality for the ACL base mode. The if block needs to run to save the changes in the base edit mode. But $aclDialog is always true in this specific mode. This results in the problem that changes are not saved in the base edit mode. After this change the saving of ACL's works correct in both modes (base mode and the 'category mode').